### PR TITLE
Add Dockerfile for ganache with realitio contracts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:10
+
+RUN apt-get update && apt-get install -y jq
+
+WORKDIR ganache
+ENV PATH="./node_modules/.bin:${PATH}"
+RUN npm install ganache-cli@6.6.0
+
+# clone realitio and install dependencies
+RUN git clone https://github.com/realitio/realitio-contracts.git realitio && \
+  cd realitio && \
+  git checkout ada36fd5031e863526a1d580cc6638937b3500fb && \
+  npm install
+
+# deploy contracts in ganache
+COPY prepare_db.sh .
+RUN bash prepare_db.sh
+
+EXPOSE 8545
+
+CMD ["./node_modules/.bin/ganache-cli", "-d", "--db", "db", "-h", "0.0.0.0", "-i", "50"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,20 @@
+# Docker
+
+This Dockerfile builds an image for a container that runs `ganache-cli` with the necessary contracts pre-deployed. To
+build it, do:
+
+```
+docker build -t gnosis-cond-ganache .
+```
+
+And then run it:
+
+```
+docker run -it --rm gnosis-cond-ganache
+```
+
+The addresses of the contracts are saved in a file inside the container. You can see them with:
+
+```
+docker run -it --rm cat contracts_addresses.txt
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,5 +16,5 @@ docker run -it --rm gnosis-cond-ganache
 The addresses of the contracts are saved in a file inside the container. You can see them with:
 
 ```
-docker run -it --rm cat contracts_addresses.txt
+docker run -it --rm gnosis-cond-ganache cat contracts_addresses.txt
 ```

--- a/docker/prepare_db.sh
+++ b/docker/prepare_db.sh
@@ -1,0 +1,11 @@
+mkdir db
+ganache-cli -d --db db -i 50 &
+PID=$!
+
+# deploy realitio contracts
+(cd realitio/truffle && ../node_modules/.bin/truffle deploy --network development)
+
+# save contracts addresses
+echo "realitio: $(jq '.networks["50"].address' realitio/truffle/build/contracts/Realitio.json)" >> contracts_addresses.txt
+
+kill $PID


### PR DESCRIPTION
This PR adds a Dockerfile for a a ganache with the realitio contracts deployed. The README has instructions on how to use it.

### How it works

The Dockerfile installs some stuff, runs a bash script and then starts ganache with a directory as its db. The bash script builds the initial state of that db by starting ganache in the background and deploying the contracts.