### PR TITLE
Compute price after trade

### DIFF
--- a/app/src/util/tools.spec.ts
+++ b/app/src/util/tools.spec.ts
@@ -1,6 +1,11 @@
 /* eslint-env jest */
 import { ethers } from 'ethers'
-import { computeInitialTradeOutcomeTokens } from './tools'
+import {
+  calcNetCost,
+  calcPrice,
+  computeInitialTradeOutcomeTokens,
+  computePriceAfterTrade,
+} from './tools'
 
 describe('tools', () => {
   describe('computeInitialTradeOutcomeTokens', () => {
@@ -20,6 +25,74 @@ describe('tools', () => {
 
         expect(initialTradeOutcomeTokens[0].toString()).toEqual(expectedResult[0])
         expect(initialTradeOutcomeTokens[1].toString()).toEqual(expectedResult[1])
+      })
+    }
+  })
+
+  describe('calcPrice', () => {
+    const testCases: any = [[[100, 100], 0.5], [[100, 32], 0.8], [[100, 230], 0.2]]
+
+    for (const [[funding, holdings], expectedResult] of testCases) {
+      it(`should compute the right price for funding ${funding} and holdings ${holdings}`, () => {
+        const fundingBN = ethers.utils.bigNumberify(funding)
+        const holdingsBN = ethers.utils.bigNumberify(holdings)
+        const result = calcPrice(fundingBN, holdingsBN)
+
+        expect(result).toBeCloseTo(expectedResult)
+      })
+    }
+  })
+
+  describe('calcNetCost', () => {
+    const testCases: any = [
+      [[100, 0.5, 200, 0.5, 0], 132],
+      [[100, 0.8, 200, 0.2, 0], 176],
+      [[100, 0.5, 0, 0.5, 150], 93],
+      [[100, 0.85, 100, 0.15, 0], 88],
+    ]
+
+    for (const [[funding, priceYes, tradeYes, priceNo, tradeNo], expectedResult] of testCases) {
+      it(`should compute the right net cost, `, () => {
+        const fundingBN = ethers.utils.bigNumberify(funding)
+        const tradeYesBN = ethers.utils.bigNumberify(tradeYes)
+        const tradeNoBN = ethers.utils.bigNumberify(tradeNo)
+        const result = calcNetCost(fundingBN, priceYes, tradeYesBN, priceNo, tradeNoBN).toNumber()
+
+        expect(result).toBeCloseTo(expectedResult)
+      })
+    }
+  })
+
+  describe('computePriceAfterTrade', () => {
+    const testCases: any = [
+      [[100, 50, 0, 100, 100], [0.58579, 0.41421]],
+      [[100, 0, 50, 100, 100], [0.41421, 0.58579]],
+      [[100, 50, 0, 77, 127], [0.6666, 0.3333]],
+      [[100, 0, 50, 77, 127], [0.5, 0.5]],
+      [[100, -50, 0, 100, 100], [0.41421, 0.58579]],
+      [[100, 50, 50, 100, 100], [0.5, 0.5]],
+    ]
+
+    for (const [
+      [funding, tradeYes, tradeNo, holdingsYes, holdingsNo],
+      [expectedPriceYes, expectedPriceNo],
+    ] of testCases) {
+      it(`should compute the right net cost, `, () => {
+        const fundingBN = ethers.utils.bigNumberify(funding)
+        const tradeYesBN = ethers.utils.bigNumberify(tradeYes)
+        const tradeNoBN = ethers.utils.bigNumberify(tradeNo)
+        const holdingsYesBN = ethers.utils.bigNumberify(holdingsYes)
+        const holdingsNoBN = ethers.utils.bigNumberify(holdingsNo)
+        const [newPriceYes, newPriceNo] = computePriceAfterTrade(
+          tradeYesBN,
+          tradeNoBN,
+          holdingsYesBN,
+          holdingsNoBN,
+          fundingBN,
+        )
+
+        expect(newPriceYes).toBeCloseTo(expectedPriceYes)
+        expect(newPriceNo).toBeCloseTo(expectedPriceNo)
       })
     }
   })

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -45,3 +45,70 @@ export const formatDate = (date: Date): string => {
   const dateParts = date.toString().split(/\s+/)
   return dateParts.slice(1, 6).join(' ')
 }
+
+const divBN = (a: BigNumber, b: BigNumber, scale = 10000): number => {
+  return (
+    a
+      .mul(scale)
+      .div(b)
+      .toNumber() / scale
+  )
+}
+
+const mulBN = (a: BigNumber, b: number, scale = 10000): BigNumber => {
+  return a.mul(Math.round(b * scale)).div(scale)
+}
+
+/**
+ * Computes the price of some outcome tokens, given the initial funding and the current holdings.
+ */
+export const calcPrice = (funding: BigNumber, holdings: BigNumber) => {
+  // 2^(-holding / funding)
+  return Math.pow(2, -divBN(holdings, funding))
+}
+
+/**
+ * Computes the cost in collateral of trading `tradeYes` and `tradeNo` outcomes, given that the initial funding is
+ * `funding` and the current prices.
+ */
+export const calcNetCost = (
+  funding: BigNumber,
+  priceYes: number,
+  tradeYes: BigNumber,
+  priceNo: number,
+  tradeNo: BigNumber,
+): number => {
+  // funding * log2(oddYes * (2^(tradeYes / funding)) + oddNo * (2^(tradeNo / funding)))
+  const logTerm = Math.log2(
+    priceYes * Math.pow(2, divBN(tradeYes, funding)) +
+      priceNo * Math.pow(2, divBN(tradeNo, funding)),
+  )
+  return mulBN(funding, logTerm)
+}
+
+/**
+ * Computes the price of the outcome tokens after trading `tradeYes` and `tradeNo`, given the initial funding is
+ * `funding` and holdings.
+ *
+ * Returns an array with the price the `yes` and the `no` outcome tokens will have after executing that trade.
+ */
+export const computePriceAfterTrade = (
+  tradeYes: BigNumber,
+  tradeNo: BigNumber,
+  holdingsYes: BigNumber,
+  holdingsNo: BigNumber,
+  funding: BigNumber,
+): [number, number] => {
+  const priceYes = calcPrice(funding, holdingsYes)
+  const priceNo = calcPrice(funding, holdingsNo)
+
+  const netCost = calcNetCost(funding, priceYes, tradeYes, priceNo, tradeNo)
+
+  const newHoldingsYes = holdingsYes.sub(tradeYes).add(netCost)
+  const newHoldingsNo = holdingsNo.sub(tradeNo).add(netCost)
+
+  const newPriceYes = calcPrice(funding, newHoldingsYes)
+  const newPriceNo = calcPrice(funding, newHoldingsNo)
+
+  return [newPriceYes, newPriceNo]
+}

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -77,7 +77,7 @@ export const calcNetCost = (
   tradeYes: BigNumber,
   priceNo: number,
   tradeNo: BigNumber,
-): number => {
+): BigNumber => {
   // funding * log2(oddYes * (2^(tradeYes / funding)) + oddNo * (2^(tradeNo / funding)))
   const logTerm = Math.log2(
     priceYes * Math.pow(2, divBN(tradeYes, funding)) +


### PR DESCRIPTION
Adds a `computePriceAfterTrade` function that computes the price the outcome tokens will have after executing some trade, given the initial funding and the current holdings (the holdings are the balance of the market maker in each token).