### PR TITLE
Fix overflow when computing price after buying

### DIFF
--- a/app/src/components/market/profile/buy.tsx
+++ b/app/src/components/market/profile/buy.tsx
@@ -120,14 +120,14 @@ const Buy = (props: Props) => {
     const amount = valueNumber / price
 
     const amountInWei = ethers.utils
-      .bigNumberify(Math.round(10000 * amount))
+      .bigNumberify('' + Math.round(10000 * amount)) // cast to string to avoid overflows
       .mul(ethers.constants.WeiPerEther)
       .div(10000)
 
     setTradedShares(amountInWei)
 
     const costWithFee = ethers.utils
-      .bigNumberify(Math.round(valueNumber * 1.01 * 10000))
+      .bigNumberify('' + Math.round(valueNumber * 1.01 * 10000)) // cast to string to avoid overflows
       .mul(ethers.constants.WeiPerEther)
       .div(10000)
     setCost(costWithFee)

--- a/app/src/util/tools.spec.ts
+++ b/app/src/util/tools.spec.ts
@@ -49,6 +49,8 @@ describe('tools', () => {
       [[100, 0.8, 200, 0.2, 0], 176],
       [[100, 0.5, 0, 0.5, 150], 93],
       [[100, 0.85, 100, 0.15, 0], 88],
+      [[100, 0.85, 200000, 0.15, 0], 199976],
+      [[100, 0.85, 0, 0.15, 200000], 199726],
     ]
 
     for (const [[funding, priceYes, tradeYes, priceNo, tradeNo], expectedResult] of testCases) {

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -78,11 +78,15 @@ export const calcNetCost = (
   priceNo: number,
   tradeNo: BigNumber,
 ): BigNumber => {
-  // funding * log2(oddYes * (2^(tradeYes / funding)) + oddNo * (2^(tradeNo / funding)))
-  const logTerm = Math.log2(
-    priceYes * Math.pow(2, divBN(tradeYes, funding)) +
-      priceNo * Math.pow(2, divBN(tradeNo, funding)),
-  )
+  // funding * (offset + log2(oddYes * (2^(tradeYes / funding - offset)) + oddNo * (2^(tradeNo / funding) - offset))
+  const offset = Math.max(divBN(tradeYes, funding), divBN(tradeNo, funding))
+
+  const logTerm =
+    offset +
+    Math.log2(
+      priceYes * Math.pow(2, divBN(tradeYes, funding) - offset) +
+        priceNo * Math.pow(2, divBN(tradeNo, funding) - offset),
+    )
   return mulBN(funding, logTerm)
 }
 


### PR DESCRIPTION
Closes #81.

There are still some issues if you put a really big number, like 100 millions times the initial funding, but this is a significant improvement (before this you couldn't use a number 1000 times the initial funding).