### PR TITLE
Add  waitForTransaction methods

### DIFF
--- a/app/src/services/conditional_token.ts
+++ b/app/src/services/conditional_token.ts
@@ -24,6 +24,7 @@ class ConditionalTokenService {
   contract: Contract
   address: string
   signerAddress: string
+  provider: any
 
   constructor(address: string, provider: any, signerAddress: string) {
     const signer: Wallet = provider.getSigner()
@@ -32,6 +33,7 @@ class ConditionalTokenService {
 
     this.address = address
     this.signerAddress = signerAddress
+    this.provider = provider
   }
 
   prepareCondition = async (
@@ -45,6 +47,7 @@ class ConditionalTokenService {
       outcomeSlotCount,
     )
     logger.log(`Prepare condition transaction hash: ${transactionObject.hash}`)
+    await this.provider.waitForTransaction(transactionObject.hash)
 
     const conditionId = ethers.utils.solidityKeccak256(
       ['address', 'bytes32', 'uint256'],

--- a/app/src/services/erc20.ts
+++ b/app/src/services/erc20.ts
@@ -44,6 +44,7 @@ class ERC20Service {
 
     const transactionObject = await erc20Contract.approve(spender, amount)
     logger.log(`Approve transaccion hash: ${transactionObject.hash}`)
+    await provider.waitForTransaction(transactionObject.hash)
   }
 
   /**
@@ -56,6 +57,7 @@ class ERC20Service {
 
     const transactionObject = await erc20Contract.approve(spender, ethers.constants.MaxUint256)
     logger.log(`Approve unlimited transaccion hash: ${transactionObject.hash}`)
+    await provider.waitForTransaction(transactionObject.hash)
   }
 
   getCollateral = async (marketMakerAddress: string, provider: any): Promise<any> => {

--- a/app/src/services/market_maker_factory.ts
+++ b/app/src/services/market_maker_factory.ts
@@ -13,6 +13,7 @@ class MarketMakerFactoryService {
   contract: Contract
   constantContract: Contract
   signerAddress: string
+  provider: any
 
   constructor(address: string, provider: any, signerAddress: string) {
     const signer: Wallet = provider.getSigner()
@@ -20,6 +21,7 @@ class MarketMakerFactoryService {
     this.contract = new ethers.Contract(address, marketMakerFactoryAbi, provider).connect(signer)
     this.constantContract = new ethers.Contract(address, marketMakerFactoryCallAbi, provider)
     this.signerAddress = signerAddress
+    this.provider = provider
   }
 
   createMarketMaker = async (
@@ -33,7 +35,8 @@ class MarketMakerFactoryService {
       from: this.signerAddress,
     })
 
-    await this.contract.createFixedProductMarketMaker(...args)
+    const transactionObject = await this.contract.createFixedProductMarketMaker(...args)
+    await this.provider.waitForTransaction(transactionObject.hash)
 
     return marketMakerAddress
   }

--- a/app/src/services/realitio.ts
+++ b/app/src/services/realitio.ts
@@ -19,6 +19,7 @@ class RealitioService {
   constantContract: Contract
   signerAddress: string
   arbitratorAddress: string
+  provider: any
 
   constructor(address: string, provider: any, signerAddress: string, arbitratorAddress: string) {
     const signer: Wallet = provider.getSigner()
@@ -27,6 +28,7 @@ class RealitioService {
     this.constantContract = new ethers.Contract(address, realitioCallAbi, provider)
     this.signerAddress = signerAddress
     this.arbitratorAddress = arbitratorAddress
+    this.provider = provider
   }
 
   /**
@@ -58,6 +60,7 @@ class RealitioService {
       value: ethers.utils.bigNumberify(value),
     })
     logger.log(`Ask question transaction hash: ${transactionObject.hash}`)
+    await this.provider.waitForTransaction(transactionObject.hash)
 
     return questionId
   }


### PR DESCRIPTION
No issue related

Tested with Trust Web3 browser that can be used to interact with any decentralized application, we found some problems related to the time we wait for a transaction to finish, this cause some transaccions to fail on mainnet.

### Includes
- Added waitForTransaccion methods in the main market creation transactions 
