### PR TITLE
Add select arbitrator

### DIFF
--- a/app/src/components/common/arbitrators/index.tsx
+++ b/app/src/components/common/arbitrators/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Select } from '../select'
+import { knownArbitrators } from '../../../util/addresses'
+
+interface Props {
+  autoFocus?: boolean
+  disabled?: boolean
+  name: string
+  onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => any
+  onClick?: (event: React.MouseEvent<HTMLSelectElement>) => any
+  readOnly?: boolean
+  value: string
+}
+
+const FormOption = styled.option``
+
+const arbitrators = Object.entries(knownArbitrators).map(([id, knownArbitrator]) => ({
+  label: knownArbitrator.name,
+  value: id,
+}))
+
+export const Arbitrators = (props: Props) => {
+  const { ...restProps } = props
+
+  return (
+    <Select {...restProps}>
+      {arbitrators.map((arbitrator: any) => {
+        return (
+          <FormOption key={arbitrator.value} value={arbitrator.value}>
+            {arbitrator.label}
+          </FormOption>
+        )
+      })}
+    </Select>
+  )
+}

--- a/app/src/components/market/market_view.tsx
+++ b/app/src/components/market/market_view.tsx
@@ -3,19 +3,20 @@ import { BigNumber } from 'ethers/utils'
 
 import { SectionTitle } from '../common/section_title'
 import { ClosedMarketDetail } from './profile/closed_market_detail'
-import { Status, BalanceItem, WinnerOutcome, Token } from '../../util/types'
+import { Status, BalanceItem, WinnerOutcome, Token, Arbitrator } from '../../util/types'
 import { View } from './profile/view'
 import { formatDate } from '../../util/tools'
 
 interface Props {
   balance: BalanceItem[]
   funding: BigNumber
-  question: string
-  resolution: Maybe<Date>
   status: Status
   marketMakerAddress: string
   winnerOutcome: Maybe<WinnerOutcome>
   collateral: Token
+  question: string
+  resolution: Maybe<Date>
+  arbitrator: Arbitrator
 }
 
 const MarketView = (props: Props) => {

--- a/app/src/components/market/market_view_container.tsx
+++ b/app/src/components/market/market_view_container.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { MarketView } from './market_view'
 import { useConnectedWeb3Context } from '../../hooks/connectedWeb3'
 import { FullLoading } from '../common/full_loading'
-import { useQuestion } from '../../hooks/useQuestion'
 import { useMarketMakerData } from '../../hooks/useMarketMakerData'
 
 interface Props {
@@ -15,13 +14,18 @@ const MarketViewContainer = (props: Props) => {
 
   const { marketMakerAddress } = props
 
-  const { question, resolution } = useQuestion(marketMakerAddress, context)
-  const { marketMakerFunding, balance, winnerOutcome, status, collateral } = useMarketMakerData(
-    marketMakerAddress,
-    context,
-  )
+  const {
+    marketMakerFunding,
+    balance,
+    winnerOutcome,
+    status,
+    collateral,
+    question,
+    resolution,
+    arbitrator,
+  } = useMarketMakerData(marketMakerAddress, context)
 
-  if (!collateral) {
+  if (!collateral || !arbitrator) {
     return <FullLoading />
   }
 
@@ -30,11 +34,12 @@ const MarketViewContainer = (props: Props) => {
       balance={balance}
       funding={marketMakerFunding}
       marketMakerAddress={marketMakerAddress}
-      question={question || ''}
-      resolution={resolution}
       status={status}
       winnerOutcome={winnerOutcome}
       collateral={collateral}
+      question={question || ''}
+      resolution={resolution}
+      arbitrator={arbitrator}
     />
   )
 }

--- a/app/src/components/market/market_wizard_creator.tsx
+++ b/app/src/components/market/market_wizard_creator.tsx
@@ -19,6 +19,7 @@ export interface MarketData {
   question: string
   category: string
   resolution: Date | null
+  arbitratorId: KnownArbitrator
   spread: string
   funding: BigNumber
   outcomeValueOne: string
@@ -47,6 +48,7 @@ export class MarketWizardCreator extends Component<Props, State> {
       question: '',
       category: '',
       resolution: null,
+      arbitratorId: 'realitio',
       spread: '1',
       funding: new BigNumber('0'),
       outcomeValueOne: 'Yes',
@@ -116,6 +118,7 @@ export class MarketWizardCreator extends Component<Props, State> {
       question,
       category,
       resolution,
+      arbitratorId,
       spread,
       funding,
       outcomeValueOne,
@@ -131,7 +134,7 @@ export class MarketWizardCreator extends Component<Props, State> {
             handleChange={this.handleChange}
             handleChangeDate={this.handleChangeDate}
             next={() => this.next()}
-            values={{ question, category, resolution }}
+            values={{ question, category, resolution, arbitratorId }}
           />
         )
       case 2:
@@ -175,7 +178,7 @@ export class MarketWizardCreator extends Component<Props, State> {
             handleChange={this.handleChange}
             handleChangeDate={this.handleChangeDate}
             next={() => this.next()}
-            values={{ question, category, resolution }}
+            values={{ question, category, resolution, arbitratorId }}
           />
         )
     }

--- a/app/src/components/market/market_wizard_creator_container.tsx
+++ b/app/src/components/market/market_wizard_creator_container.tsx
@@ -42,16 +42,14 @@ const MarketWizardCreatorContainer: FC = () => {
 
       const collateralToken = getToken(networkId, collateralId)
       const arbitrator = getArbitrator(networkId, arbitratorId)
-      const oracleAddress: string =
-        process.env.NODE_ENV === 'development' ? user : arbitrator.address
 
       setStatus(StatusMarketCreation.PostingQuestion)
-      const questionId = await realitio.askQuestion(question, oracleAddress, openingDateMoment)
+      const questionId = await realitio.askQuestion(question, arbitrator.address, openingDateMoment)
       setQuestionId(questionId)
 
       setStatus(StatusMarketCreation.PrepareCondition)
 
-      const conditionId = await conditionalTokens.prepareCondition(questionId, oracleAddress)
+      const conditionId = await conditionalTokens.prepareCondition(questionId, arbitrator.address)
 
       // approve movement of collateral token to MarketMakerFactory
       setStatus(StatusMarketCreation.ApprovingCollateral)

--- a/app/src/components/market/market_wizard_creator_container.tsx
+++ b/app/src/components/market/market_wizard_creator_container.tsx
@@ -5,7 +5,7 @@ import { getLogger } from '../../util/logger'
 import { StatusMarketCreation } from '../../util/types'
 import { MarketWizardCreator, MarketData } from './market_wizard_creator'
 import { ERC20Service, MarketMakerService } from '../../services'
-import { getContractAddress, getToken } from '../../util/addresses'
+import { getArbitrator, getContractAddress, getToken } from '../../util/addresses'
 import { useConnectedWeb3Context } from '../../hooks/connectedWeb3'
 import { useContracts } from '../../hooks/useContracts'
 
@@ -31,6 +31,7 @@ const MarketWizardCreatorContainer: FC = () => {
 
       const {
         collateralId,
+        arbitratorId,
         question,
         resolution,
         funding,
@@ -40,17 +41,16 @@ const MarketWizardCreatorContainer: FC = () => {
       const openingDateMoment = moment(resolution)
 
       const collateralToken = getToken(networkId, collateralId)
+      const arbitrator = getArbitrator(networkId, arbitratorId)
+      const oracleAddress: string =
+        process.env.NODE_ENV === 'development' ? user : arbitrator.address
 
       setStatus(StatusMarketCreation.PostingQuestion)
-      const questionId = await realitio.askQuestion(question, openingDateMoment)
+      const questionId = await realitio.askQuestion(question, oracleAddress, openingDateMoment)
       setQuestionId(questionId)
 
       setStatus(StatusMarketCreation.PrepareCondition)
 
-      const oracleAddress: string =
-        process.env.NODE_ENV === 'development'
-          ? user
-          : getContractAddress(networkId, 'realitioArbitrator')
       const conditionId = await conditionalTokens.prepareCondition(questionId, oracleAddress)
 
       // approve movement of collateral token to MarketMakerFactory

--- a/app/src/components/market/profile/view.tsx
+++ b/app/src/components/market/profile/view.tsx
@@ -5,20 +5,24 @@ import { withRouter, RouteComponentProps } from 'react-router-dom'
 import { ThreeBoxComments } from '../../common/three_box_comments'
 import { ViewCard } from '../../common/view_card'
 import { formatBigNumber } from '../../../util/tools'
-import { Status, BalanceItem, Token } from '../../../util/types'
+import { Status, BalanceItem, Token, Arbitrator } from '../../../util/types'
 import { ButtonAnchor } from '../../common'
 import { FullLoading } from '../../common/full_loading'
 import { ButtonContainer } from '../../common/button_container'
 import { Table, TD, TH, THead, TR } from '../../common/table'
 import { SubsectionTitle } from '../../common/subsection_title'
+import { BigNumber } from 'ethers/utils'
+import { TitleValue } from '../../common/title_value'
 
 interface Props extends RouteComponentProps<{}> {
   balance: BalanceItem[]
   collateral: Token
+  arbitrator: Arbitrator
   question: string
   status: Status
   theme?: any
   marketMakerAddress: string
+  funding: BigNumber
 }
 
 const ButtonContainerStyled = styled(ButtonContainer)`
@@ -38,9 +42,16 @@ const ButtonContainerStyled = styled(ButtonContainer)`
     }
   }
 `
+const Grid = styled.div`
+  display: grid;
+  grid-column-gap: 20px;
+  grid-row-gap: 14px;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 25px;
+`
 
 const ViewWrapper = (props: Props) => {
-  const { balance, collateral, status, theme, marketMakerAddress } = props
+  const { balance, collateral, status, theme, marketMakerAddress, arbitrator } = props
 
   const userHasShares = balance.some((balanceItem: BalanceItem) => {
     const { shares } = balanceItem
@@ -87,9 +98,30 @@ const ViewWrapper = (props: Props) => {
     })
   }
 
+  const details = () => {
+    return (
+      <>
+        <SubsectionTitle>Details</SubsectionTitle>
+        <Grid>
+          <TitleValue title={'Category'} value={'TODO: Add category'} />
+          <TitleValue
+            title={'Oracle'}
+            value={[
+              <a href={arbitrator.url} key={1} rel="noopener noreferrer" target="_blank">
+                {arbitrator.name}
+              </a>,
+              ' oracle as final arbitrator.',
+            ]}
+          />
+        </Grid>
+      </>
+    )
+  }
+
   return (
     <>
       <ViewCard>
+        {details()}
         {userHasShares && <SubsectionTitle>Balance</SubsectionTitle>}
         <Table head={renderTableHeader()}>{renderTableData()}</Table>
         <ButtonContainerStyled>

--- a/app/src/components/market/steps/items/ask_question_step.tsx
+++ b/app/src/components/market/steps/items/ask_question_step.tsx
@@ -1,11 +1,14 @@
 import React, { ChangeEvent, Component } from 'react'
 import styled from 'styled-components'
+
 import { CreateCard } from '../../create_card'
 import { Button, Textfield, Categories } from '../../../common/index'
 import { FormRow } from '../../../common/form_row'
 import { DateField } from '../../../common/date_field'
 import { ButtonContainer } from '../../../common/button_container'
 import { Well } from '../../../common/well'
+import { Arbitrators } from '../../../common/arbitrators'
+import { knownArbitrators } from '../../../../util/addresses'
 
 interface Props {
   next: () => void
@@ -13,6 +16,7 @@ interface Props {
     question: string
     category: string
     resolution: Date | null
+    arbitratorId: KnownArbitrator
   }
   handleChange: (event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLSelectElement>) => any
   handleChangeDate: (date: Date | null) => any
@@ -52,7 +56,9 @@ class AskQuestionStep extends Component<Props, State> {
 
   render() {
     const { values, handleChange, handleChangeDate } = this.props
-    const { question, category, resolution } = values
+    const { question, category, resolution, arbitratorId } = values
+
+    const arbitrator = knownArbitrators[arbitratorId]
 
     return (
       <CreateCard>
@@ -96,20 +102,21 @@ class AskQuestionStep extends Component<Props, State> {
         />
         <FormRow
           formField={
-            <OracleInfo>
-              The market will be resolved using the{' '}
-              <a href="https://realit.io/" rel="noopener noreferrer" target="_blank">
-                realit.io
-              </a>{' '}
-              oracle and using{' '}
-              <a href="https://dxdao.daostack.io/" rel="noopener noreferrer" target="_blank">
-                dxDAO
-              </a>{' '}
-              as final arbitrator.
-            </OracleInfo>
+            <>
+              <Arbitrators name="arbitratorId" value={arbitratorId} onChange={handleChange} />
+              <OracleInfo>
+                The market will be resolved using{' '}
+                <a href={arbitrator.url} rel="noopener noreferrer" target="_blank">
+                  {arbitrator.name}
+                </a>{' '}
+                as final arbitrator.
+              </OracleInfo>
+            </>
           }
           title={'Oracle'}
-          tooltipText={'The Oracle will resolve the market once the Resolution Date is reached.'}
+          tooltipText={
+            'You can choose among several available Oracles. The Oracle will resolve the market once the Resolution Date is reached.'
+          }
         />
         <ButtonContainer>
           <Button disabled={!question || !category || !resolution} onClick={this.validate}>

--- a/app/src/components/market/steps/items/create_market_step.tsx
+++ b/app/src/components/market/steps/items/create_market_step.tsx
@@ -11,7 +11,7 @@ import { FullLoading } from '../../../common/full_loading'
 import { Table, TD, TH, THead, TR } from '../../../common/table'
 import { TitleValue } from '../../../common/title_value'
 import { SubsectionTitle } from '../../../common/subsection_title'
-import { knownTokens } from '../../../../util/addresses'
+import { knownArbitrators, knownTokens } from '../../../../util/addresses'
 import { formatBigNumber, formatDate } from '../../../../util/tools'
 import styled from 'styled-components'
 
@@ -43,6 +43,7 @@ interface Props {
     question: string
     category: string
     resolution: Date | null
+    arbitratorId: KnownArbitrator
     spread: string
     funding: BigNumber
     outcomeValueOne: string
@@ -70,6 +71,7 @@ class CreateMarketStep extends Component<Props> {
       collateralId,
       question,
       category,
+      arbitratorId,
       resolution,
       spread,
       funding,
@@ -80,6 +82,8 @@ class CreateMarketStep extends Component<Props> {
     } = values
 
     const collateral = knownTokens[collateralId]
+
+    const arbitrator = knownArbitrators[arbitratorId]
 
     const resolutionDate = resolution && formatDate(resolution)
 
@@ -100,19 +104,10 @@ class CreateMarketStep extends Component<Props> {
           <TitleValue
             title={'Oracle'}
             value={[
-              <a href="https://realit.io/" key={1} rel="noopener noreferrer" target="_blank">
-                realit.io
+              <a href={arbitrator.url} key={1} rel="noopener noreferrer" target="_blank">
+                {arbitrator.name}
               </a>,
-              ' oracle and ',
-              <a
-                href="https://dxdao.daostack.io/"
-                key={2}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                dxDAO
-              </a>,
-              ' as final arbitrator.',
+              ' oracle as final arbitrator.',
             ]}
           />
           <TitleValue title={'Spread / Fee'} value={`${spread}%`} />

--- a/app/src/components/market/steps/items/summary_market_step.tsx
+++ b/app/src/components/market/steps/items/summary_market_step.tsx
@@ -49,7 +49,7 @@ const SummaryMarketStep = (props: Props) => {
   const { marketMakerAddress } = props
 
   const { question, resolution } = useQuestion(marketMakerAddress, context)
-  const { marketMakerFunding, balance, collateral } = useMarketMakerData(
+  const { marketMakerFunding, balance, collateral, arbitrator } = useMarketMakerData(
     marketMakerAddress,
     context,
   )
@@ -57,7 +57,7 @@ const SummaryMarketStep = (props: Props) => {
   const resolutionDate = resolution && formatDate(resolution)
   const marketMakerURL = `${window.location.protocol}//${window.location.hostname}/#/${marketMakerAddress}`
 
-  if (!collateral) {
+  if (!collateral || !arbitrator) {
     return <FullLoading />
   }
 
@@ -83,19 +83,10 @@ const SummaryMarketStep = (props: Props) => {
           <TitleValue
             title={'Oracle'}
             value={[
-              <a href="https://realit.io/" key={1} rel="noopener noreferrer" target="_blank">
-                realit.io
+              <a href={arbitrator.url} key={1} rel="noopener noreferrer" target="_blank">
+                {arbitrator.name}
               </a>,
-              ' oracle and ',
-              <a
-                href="https://dxdao.daostack.io/"
-                key={2}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                dxDAO
-              </a>,
-              ' as final arbitrator.',
+              ' oracle as final arbitrator.',
             ]}
           />
           <TitleValue title={'Spread / Fee'} value={`1%`} />

--- a/app/src/global.d.ts
+++ b/app/src/global.d.ts
@@ -5,3 +5,5 @@ declare module '3box-comments-react'
 declare type Maybe<T> = T | null
 
 declare type KnownToken = 'dai' | 'usdc'
+
+declare type KnownArbitrator = 'kleros' | 'realitio'

--- a/app/src/hooks/useContracts.tsx
+++ b/app/src/hooks/useContracts.tsx
@@ -18,11 +18,11 @@ export const useContracts = (context: ConnectedWeb3Context) => {
   )
 
   const realitioAddress = getContractAddress(networkId, 'realitio')
-  const arbitratorAddress = getContractAddress(networkId, 'realitioArbitrator')
-  const realitio = useMemo(
-    () => new RealitioService(realitioAddress, library, account, arbitratorAddress),
-    [realitioAddress, library, account, arbitratorAddress],
-  )
+  const realitio = useMemo(() => new RealitioService(realitioAddress, library, account), [
+    realitioAddress,
+    library,
+    account,
+  ])
 
   return {
     conditionalTokens,

--- a/app/src/hooks/useMarketMakerData.tsx
+++ b/app/src/hooks/useMarketMakerData.tsx
@@ -3,17 +3,14 @@ import { BigNumber } from 'ethers/utils'
 
 import { ConnectedWeb3Context } from './connectedWeb3'
 import { MarketMakerService } from '../services'
-import { getTokenFromAddress } from '../util/addresses'
+import { getArbitratorFromAddress, getTokenFromAddress } from '../util/addresses'
 import { useContracts } from './useContracts'
 import { getLogger } from '../util/logger'
-import { BalanceItem, OutcomeSlot, Status, WinnerOutcome, Token } from '../util/types'
+import { BalanceItem, OutcomeSlot, Status, WinnerOutcome, Token, Arbitrator } from '../util/types'
 
 const logger = getLogger('Market::useMarketMakerData')
 
-export const useMarketMakerData = (
-  marketMakerAddress: string,
-  context: ConnectedWeb3Context,
-): {
+interface MarketMakerData {
   totalPoolShares: BigNumber
   userPoolShares: BigNumber
   balance: BalanceItem[]
@@ -22,8 +19,16 @@ export const useMarketMakerData = (
   marketMakerFunding: BigNumber
   marketMakerUserFunding: BigNumber
   collateral: Maybe<Token>
-} => {
-  const { conditionalTokens } = useContracts(context)
+  question: string
+  resolution: Maybe<Date>
+  arbitrator: Maybe<Arbitrator>
+}
+
+export const useMarketMakerData = (
+  marketMakerAddress: string,
+  context: ConnectedWeb3Context,
+): MarketMakerData => {
+  const { conditionalTokens, realitio } = useContracts(context)
 
   const [totalPoolShares, setTotalPoolShares] = useState<BigNumber>(new BigNumber(0))
   const [userPoolShares, setUserPoolShares] = useState<BigNumber>(new BigNumber(0))
@@ -33,6 +38,9 @@ export const useMarketMakerData = (
   const [marketMakerFunding, setMarketMakerFunding] = useState<BigNumber>(new BigNumber(0))
   const [marketMakerUserFunding, setMarketMakerUserFunding] = useState<BigNumber>(new BigNumber(0))
   const [collateral, setCollateral] = useState<Maybe<Token>>(null)
+  const [question, setQuestion] = useState<string>('')
+  const [resolution, setResolution] = useState<Maybe<Date>>(null)
+  const [arbitrator, setArbitrator] = useState<Maybe<Arbitrator>>(null)
 
   useEffect(() => {
     const fetchMarketMakerData = async ({ enableStatus }: { enableStatus: boolean }) => {
@@ -45,6 +53,17 @@ export const useMarketMakerData = (
 
         const conditionId = await marketMaker.getConditionId()
         const isConditionResolved = await conditionalTokens.isConditionResolved(conditionId)
+
+        const questionId = await conditionalTokens.getQuestionId(conditionId, provider)
+        const { question, resolution, arbitratorAddress } = await realitio.getQuestion(
+          questionId,
+          provider,
+        )
+
+        const arbitratorObject = getArbitratorFromAddress(context.networkId, arbitratorAddress)
+        setArbitrator(arbitratorObject)
+        setQuestion(question)
+        setResolution(resolution)
 
         const winnerOutcomeData = isConditionResolved
           ? await conditionalTokens.getWinnerOutcome(conditionId)
@@ -117,7 +136,7 @@ export const useMarketMakerData = (
     }, 2000)
 
     return () => clearInterval(intervalId)
-  }, [marketMakerAddress, context, conditionalTokens, winnerOutcome])
+  }, [marketMakerAddress, context, conditionalTokens, winnerOutcome, realitio])
 
   return {
     totalPoolShares,
@@ -128,5 +147,8 @@ export const useMarketMakerData = (
     marketMakerFunding,
     marketMakerUserFunding,
     collateral,
+    question,
+    resolution,
+    arbitrator,
   }
 }

--- a/app/src/hooks/useQuestion.tsx
+++ b/app/src/hooks/useQuestion.tsx
@@ -16,6 +16,7 @@ export const useQuestion = (
 
   const [question, setQuestion] = useState<string>('')
   const [resolution, setResolution] = useState<Maybe<Date>>(null)
+  const [arbitrator, setArbitrator] = useState<string>('')
 
   useEffect(() => {
     const fetchQuestion = async () => {
@@ -26,10 +27,14 @@ export const useQuestion = (
 
         const conditionId = await marketMaker.getConditionId()
         const questionId = await conditionalTokens.getQuestionId(conditionId, provider)
-        const { question, resolution } = await realitio.getQuestion(questionId, provider)
+        const { question, resolution, arbitratorAddress } = await realitio.getQuestion(
+          questionId,
+          provider,
+        )
 
         setQuestion(question)
         setResolution(resolution)
+        setArbitrator(arbitratorAddress)
       } catch (error) {
         logger.error('There was an error fetching the question data:', error.message)
       }
@@ -38,5 +43,5 @@ export const useQuestion = (
     fetchQuestion()
   }, [marketMakerAddress, context, conditionalTokens, realitio])
 
-  return { question, resolution }
+  return { question, resolution, arbitratorAddress: arbitrator }
 }

--- a/app/src/hooks/useQuestion.tsx
+++ b/app/src/hooks/useQuestion.tsx
@@ -16,7 +16,7 @@ export const useQuestion = (
 
   const [question, setQuestion] = useState<string>('')
   const [resolution, setResolution] = useState<Maybe<Date>>(null)
-  const [arbitrator, setArbitrator] = useState<string>('')
+  const [arbitratorAddress, setArbitratorAddress] = useState<string>('')
 
   useEffect(() => {
     const fetchQuestion = async () => {
@@ -34,7 +34,7 @@ export const useQuestion = (
 
         setQuestion(question)
         setResolution(resolution)
-        setArbitrator(arbitratorAddress)
+        setArbitratorAddress(arbitratorAddress)
       } catch (error) {
         logger.error('There was an error fetching the question data:', error.message)
       }
@@ -43,5 +43,5 @@ export const useQuestion = (
     fetchQuestion()
   }, [marketMakerAddress, context, conditionalTokens, realitio])
 
-  return { question, resolution, arbitratorAddress: arbitrator }
+  return { question, resolution, arbitratorAddress }
 }

--- a/app/src/services/realitio.ts
+++ b/app/src/services/realitio.ts
@@ -84,7 +84,7 @@ class RealitioService {
     return {
       question: event.values.question,
       resolution: new Date(event.values.opening_ts * 1000),
-      arbitratorAddress: event.values.arbitratorAddress,
+      arbitratorAddress: event.values.arbitrator,
     }
   }
 }

--- a/app/src/services/realitio.ts
+++ b/app/src/services/realitio.ts
@@ -84,6 +84,7 @@ class RealitioService {
     return {
       question: event.values.question,
       resolution: new Date(event.values.opening_ts * 1000),
+      arbitratorAddress: event.values.arbitratorAddress,
     }
   }
 }

--- a/app/src/services/realitio.ts
+++ b/app/src/services/realitio.ts
@@ -18,16 +18,14 @@ class RealitioService {
   contract: Contract
   constantContract: Contract
   signerAddress: string
-  arbitratorAddress: string
   provider: any
 
-  constructor(address: string, provider: any, signerAddress: string, arbitratorAddress: string) {
+  constructor(address: string, provider: any, signerAddress: string) {
     const signer: Wallet = provider.getSigner()
 
     this.contract = new ethers.Contract(address, realitioAbi, provider).connect(signer)
     this.constantContract = new ethers.Contract(address, realitioCallAbi, provider)
     this.signerAddress = signerAddress
-    this.arbitratorAddress = arbitratorAddress
     this.provider = provider
   }
 
@@ -45,11 +43,12 @@ class RealitioService {
    */
   askQuestion = async (
     question: string,
+    arbitratorAddress: string,
     openingDateMoment: Moment,
     value = '0',
   ): Promise<string> => {
     const openingTimestamp = openingDateMoment.unix()
-    const args = [0, question, this.arbitratorAddress, '86400', openingTimestamp, 0]
+    const args = [0, question, arbitratorAddress, '86400', openingTimestamp, 0]
 
     const questionId = await this.constantContract.askQuestion(...args, {
       from: this.signerAddress,

--- a/app/src/util/addresses.ts
+++ b/app/src/util/addresses.ts
@@ -1,4 +1,4 @@
-import { Token } from './types'
+import { Token, Arbitrator } from './types'
 
 const networkIds = {
   MAINNET: 1,
@@ -8,7 +8,6 @@ const networkIds = {
 
 interface KnownContracts {
   realitio: string
-  realitioArbitrator: string
   marketMakerFactory: string
   conditionalTokens: string
 }
@@ -24,21 +23,18 @@ interface KnownTokenData {
 const addresses: { [networkId: number]: KnownContracts } = {
   [networkIds.MAINNET]: {
     realitio: '0x325a2e0f3cca2ddbaebb4dfc38df8d19ca165b47',
-    realitioArbitrator: '0xdc0a2185031ecf89f091a39c63c2857a7d5c301a',
     marketMakerFactory: '0x4967C09AB3cDed1b4E21739f74b036eADA243C8A',
     conditionalTokens: '0xC59b0e4De5F1248C1140964E0fF287B192407E0C',
   },
   [networkIds.RINKEBY]: {
     realitio: '0x3D00D77ee771405628a4bA4913175EcC095538da',
     // realitioArbitrator: '0x02321745bE4a141E78db6C39834396f8df00e2a0',
-    // using a custom address as arbitrator for testing
-    realitioArbitrator: '0xAEC3C8eD9516A206a4fD47EC77f026EDD533CF17',
+    // using a custom address as arbitratorId for testing
     marketMakerFactory: '0xF248C1fe91eC1a5DD78bF26EB43489cDc6aAd1dD',
     conditionalTokens: '0xe6Cdc22F99FD9ffdC03647C7fFF5bB753a4eBB21',
   },
   [networkIds.GANACHE]: {
     realitio: '0xcfeb869f69431e42cdb54a4f4f105c19c080a601',
-    realitioArbitrator: '0x254dffcd3277c0b1660f6d42efbb754edababc2b',
     marketMakerFactory: '0x21a59654176f2689d12E828B77a783072CD26680',
     conditionalTokens: '0x0290FB167208Af455bB137780163b7B7a9a10C16',
   },
@@ -113,4 +109,67 @@ export const getContractAddressName = (networkId: number) => {
   const networkNameCase =
     networkName && networkName.substr(0, 1).toUpperCase() + networkName.substr(1).toLowerCase()
   return networkNameCase
+}
+
+interface KnownArbitratorData {
+  name: string
+  url: string
+  addresses: {
+    [networkId: number]: string
+  }
+}
+
+export const knownArbitrators: { [name in KnownArbitrator]: KnownArbitratorData } = {
+  kleros: {
+    name: 'Kleros',
+    url: 'https://kleros.io/',
+    addresses: {
+      [networkIds.MAINNET]: '0xd47f72a2d1d0E91b0Ec5e5f5d02B2dc26d00A14D',
+      [networkIds.RINKEBY]: '0xcafa054b1b054581faf65adce667bf1c684b6ef0',
+    },
+  },
+  realitio: {
+    name: 'realit.io',
+    url: 'https://realit.io/',
+    addresses: {
+      [networkIds.MAINNET]: '0xdc0a2185031ecf89f091a39c63c2857a7d5c301a',
+      [networkIds.RINKEBY]: '0x02321745bE4a141E78db6C39834396f8df00e2a0',
+    },
+  },
+}
+
+export const getArbitrator = (networkId: number, arbitratorId: KnownArbitrator): Arbitrator => {
+  const arbitrator = knownArbitrators[arbitratorId]
+  const address = arbitrator.addresses[networkId]
+
+  if (!address) {
+    throw new Error(`Unsupported network id: '${networkId}'`)
+  }
+
+  return {
+    address,
+    name: arbitrator.name,
+    url: arbitrator.url,
+  }
+}
+
+export const getArbitratorFromAddress = (networkId: number, address: string): Arbitrator => {
+  for (const arbitrator of Object.values(knownArbitrators)) {
+    const arbitratorAddress = arbitrator.addresses[networkId]
+
+    // arbitratorId might not be supported in the current network
+    if (!arbitratorAddress) {
+      continue
+    }
+
+    if (arbitratorAddress.toLowerCase() === address.toLowerCase()) {
+      return {
+        address: arbitratorAddress,
+        name: arbitrator.name,
+        url: arbitrator.url,
+      }
+    }
+  }
+
+  throw new Error(`Couldn't find arbitrator with address '${address}' in network '${networkId}'`)
 }

--- a/app/src/util/addresses.ts
+++ b/app/src/util/addresses.ts
@@ -126,6 +126,7 @@ export const knownArbitrators: { [name in KnownArbitrator]: KnownArbitratorData 
     addresses: {
       [networkIds.MAINNET]: '0xd47f72a2d1d0E91b0Ec5e5f5d02B2dc26d00A14D',
       [networkIds.RINKEBY]: '0xcafa054b1b054581faf65adce667bf1c684b6ef0',
+      [networkIds.GANACHE]: '0x0000000000000000000000000000000000c1e305',
     },
   },
   realitio: {
@@ -134,6 +135,7 @@ export const knownArbitrators: { [name in KnownArbitrator]: KnownArbitratorData 
     addresses: {
       [networkIds.MAINNET]: '0xdc0a2185031ecf89f091a39c63c2857a7d5c301a',
       [networkIds.RINKEBY]: '0x02321745bE4a141E78db6C39834396f8df00e2a0',
+      [networkIds.GANACHE]: '0x000000000000000000000000000000003ea11710',
     },
   },
 }

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -65,6 +65,7 @@ export enum WinnerOutcome {
 export interface Question {
   question: string
   resolution: Maybe<Date>
+  arbitratorAddress: string
 }
 
 export enum OutcomeTableValue {

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -81,3 +81,9 @@ export interface Token {
   decimals: number
   symbol: string
 }
+
+export interface Arbitrator {
+  address: string
+  name: string
+  url: string
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -16069,7 +16069,7 @@ pull-window@^2.1.4:
   dependencies:
     looper "^2.0.0"
 
-"pull-ws@github:hugomrdias/pull-ws#fix/bundle-size":
+pull-ws@hugomrdias/pull-ws#fix/bundle-size:
   version "3.3.1"
   resolved "https://codeload.github.com/hugomrdias/pull-ws/tar.gz/8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
   dependencies:
@@ -19994,7 +19994,6 @@ websocket@1.0.29:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
Closes #157 
Closes #158 

#### Includes
- Arbitrators component, we can used to select an arbitrator in the Market Maker creation workflow
- Display arbitrator in some sections: market maker profile, summary before creation of market marker, summary after creation of market maker
- Fetch arbitrator address from logs
- Added arbitrators for kleros and realitio, added address and network support