### PR TITLE
Add validation for unexisting arbitrator

### DIFF
--- a/app/src/components/market/market_view.tsx
+++ b/app/src/components/market/market_view.tsx
@@ -17,7 +17,7 @@ interface Props {
   question: string
   category: string
   resolution: Maybe<Date>
-  arbitrator: Arbitrator
+  arbitrator: Maybe<Arbitrator>
 }
 
 const MarketView: React.FC<Props> = (props: Props) => {

--- a/app/src/components/market/market_view_container.tsx
+++ b/app/src/components/market/market_view_container.tsx
@@ -26,7 +26,7 @@ const MarketViewContainer: React.FC<Props> = (props: Props) => {
     category,
   } = useMarketMakerData(marketMakerAddress, context)
 
-  if (!collateral || !arbitrator) {
+  if (!collateral) {
     return <FullLoading />
   }
 

--- a/app/src/components/market/profile/view.tsx
+++ b/app/src/components/market/profile/view.tsx
@@ -17,7 +17,7 @@ import { TitleValue } from '../../common/title_value'
 interface Props extends RouteComponentProps<{}> {
   balance: BalanceItem[]
   collateral: Token
-  arbitrator: Arbitrator
+  arbitrator: Maybe<Arbitrator>
   question: string
   category: string
   status: Status
@@ -104,25 +104,29 @@ const ViewWrapper = (props: Props) => {
       <>
         <SubsectionTitle>Details</SubsectionTitle>
         <Grid>
-          <TitleValue title={'Category'} value={category} />
-          <TitleValue
-            title={'Arbitrator'}
-            value={[
-              <a href={arbitrator.url} key={1} rel="noopener noreferrer" target="_blank">
-                {arbitrator.name}
-              </a>,
-              ' oracle as final arbitrator.',
-            ]}
-          />
+          {category && <TitleValue title={'Category'} value={category} />}
+          {arbitrator && (
+            <TitleValue
+              title={'Arbitrator'}
+              value={[
+                <a href={arbitrator.url} key={1} rel="noopener noreferrer" target="_blank">
+                  {arbitrator.name}
+                </a>,
+                ' oracle as final arbitrator.',
+              ]}
+            />
+          )}
         </Grid>
       </>
     )
   }
 
+  const marketHasDetails = category || arbitrator
+
   return (
     <>
       <ViewCard>
-        {details()}
+        {marketHasDetails && details()}
         {userHasShares && <SubsectionTitle>Balance</SubsectionTitle>}
         <Table head={renderTableHeader()}>{renderTableData()}</Table>
         <ButtonContainerStyled>

--- a/app/src/services/realitio.ts
+++ b/app/src/services/realitio.ts
@@ -93,14 +93,18 @@ class RealitioService {
     const iface = new ethers.utils.Interface(realitioAbi)
     const event = iface.parseLog(logs[0])
 
-    const question: QuestionLog = RealitioQuestionLib.populatedJSONForTemplate(
+    const questionLog: QuestionLog = RealitioQuestionLib.populatedJSONForTemplate(
       RealitioTemplateLib.defaultTemplateForType('bool'),
       event.values.question,
     )
 
+    const category =
+      questionLog.category && questionLog.category === 'undefined' ? '' : questionLog.category
+    const question = questionLog.title && questionLog.title === 'undefined' ? '' : questionLog.title
+
     return {
-      question: question.title,
-      category: question.category,
+      question,
+      category,
       resolution: new Date(event.values.opening_ts * 1000),
       arbitratorAddress: event.values.arbitrator,
     }

--- a/app/src/services/realitio.ts
+++ b/app/src/services/realitio.ts
@@ -98,9 +98,8 @@ class RealitioService {
       event.values.question,
     )
 
-    const category =
-      questionLog.category && questionLog.category === 'undefined' ? '' : questionLog.category
-    const question = questionLog.title && questionLog.title === 'undefined' ? '' : questionLog.title
+    const category = questionLog.category === 'undefined' ? '' : questionLog.category
+    const question = questionLog.title === 'undefined' ? '' : questionLog.title
 
     return {
       question,

--- a/app/src/util/addresses.ts
+++ b/app/src/util/addresses.ts
@@ -157,7 +157,7 @@ export const getArbitrator = (networkId: number, arbitratorId: KnownArbitrator):
   }
 }
 
-export const getArbitratorFromAddress = (networkId: number, address: string): Arbitrator => {
+export const getArbitratorFromAddress = (networkId: number, address: string): Maybe<Arbitrator> => {
   for (const arbitrator of Object.values(knownArbitrators)) {
     const arbitratorAddress = arbitrator.addresses[networkId]
 
@@ -175,5 +175,5 @@ export const getArbitratorFromAddress = (networkId: number, address: string): Ar
     }
   }
 
-  throw new Error(`Couldn't find arbitrator with address '${address}' in network '${networkId}'`)
+  return null
 }


### PR DESCRIPTION
No issue related

There are some markets created with an invalid arbitrator address, 

### Includes
- Now the `getArbitratorFromAddress` function returns null
- Add Maybe in some props for Arbitrator object
- Validate display arbitrator if exist, also for category and question title ( for example, if category doesn't exist return an 'undefined' string')