### PR TITLE
Add cleanup subscriptions

### DIFF
--- a/app/src/components/common/three_box_comments/index.tsx
+++ b/app/src/components/common/three_box_comments/index.tsx
@@ -140,21 +140,27 @@ export const ThreeBoxComments = (props: Props) => {
   const [currentUserAddress, setCurrentUserAddress] = useState<string>(context.account)
 
   useEffect(() => {
+    let isSubscribed = true
+
     const handle3boxLogin = async () => {
       const { account, library } = context
       logger.log(`Open three box with account ${account}`)
 
       const newBox = await Box.openBox(account, library._web3Provider)
       await newBox.openSpace(THREEBOX_SPACE_NAME)
-      setCurrentUserAddress(account)
+      if (isSubscribed) setCurrentUserAddress(account)
 
       newBox.onSyncDone(() => {
-        setBox(newBox)
+        if (isSubscribed) setBox(newBox)
         logger.log(`Three box sync with account ${account}`)
       })
     }
 
     handle3boxLogin()
+
+    return () => {
+      isSubscribed = false
+    }
   }, [context])
 
   return (

--- a/app/src/components/connect_wallet/index.tsx
+++ b/app/src/components/connect_wallet/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useWeb3Context } from 'web3-react'
 import styled, { css } from 'styled-components'
 import WalletConnectQRCodeModal from '@walletconnect/qrcode-modal'
@@ -42,7 +42,7 @@ export const ConnectWallet = (props: any) => {
     console.error('Error in web3 context', context.error)
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (context.active && !context.account && context.connectorName === 'WalletConnect') {
       const uri = context.connector.walletConnector.uri
       WalletConnectQRCodeModal.open(uri, () => {})

--- a/app/src/components/market/profile/closed_market_detail.tsx
+++ b/app/src/components/market/profile/closed_market_detail.tsx
@@ -72,16 +72,22 @@ export const ClosedMarketDetailWrapper = (props: Props) => {
   const marketMaker = new MarketMakerService(marketMakerAddress, conditionalTokens, provider)
 
   useEffect(() => {
+    let isSubscribed = true
+
     const fetchBalance = async () => {
       const provider = context.library
 
       const collateralAddress = await marketMaker.getCollateralToken()
       const collateralService = new ERC20Service(collateralAddress)
       const collateralBalance = await collateralService.getCollateral(marketMakerAddress, provider)
-      setCollateral(collateralBalance)
+      if (isSubscribed) setCollateral(collateralBalance)
     }
 
     fetchBalance()
+
+    return () => {
+      isSubscribed = false
+    }
   }, [collateral, context, marketMakerAddress, marketMaker])
 
   const redeem = async () => {

--- a/app/src/hooks/connectedWeb3.tsx
+++ b/app/src/hooks/connectedWeb3.tsx
@@ -47,13 +47,19 @@ export const ConnectedWeb3: React.FC<{ children: React.ReactNode }> = props => {
   const context = useWeb3Context()
 
   useEffect(() => {
+    let isSubscribed = true
+
     const checkIfReady = async () => {
       const network = await context.library.ready
-      setNetworkId(network.chainId)
+      if (isSubscribed) setNetworkId(network.chainId)
     }
 
     if (context.library) {
       checkIfReady()
+    }
+
+    return () => {
+      isSubscribed = false
     }
   }, [context.library])
 

--- a/app/src/hooks/useCheckContractExists.tsx
+++ b/app/src/hooks/useCheckContractExists.tsx
@@ -9,12 +9,16 @@ export const useCheckContractExists = (
   const [contractExists, setContractExists] = useState<boolean>(true)
 
   useEffect(() => {
+    let isSubscribed = true
     const provider = context.library
     const fetchIsContract = async () => {
-      setContractExists(await isContract(provider, marketMakerAddress))
+      if (isSubscribed) setContractExists(await isContract(provider, marketMakerAddress))
     }
 
     fetchIsContract()
+    return () => {
+      isSubscribed = false
+    }
   }, [context, marketMakerAddress])
 
   return contractExists

--- a/app/src/hooks/useMarketMakerData.tsx
+++ b/app/src/hooks/useMarketMakerData.tsx
@@ -45,6 +45,7 @@ export const useMarketMakerData = (
   const [arbitrator, setArbitrator] = useState<Maybe<Arbitrator>>(null)
 
   useEffect(() => {
+    let isSubscribed = true
     const fetchMarketMakerData = async ({ enableStatus }: { enableStatus: boolean }) => {
       try {
         enableStatus && setStatus(Status.Loading)
@@ -62,15 +63,10 @@ export const useMarketMakerData = (
         )
 
         const arbitratorObject = getArbitratorFromAddress(context.networkId, arbitratorAddress)
-        setArbitrator(arbitratorObject)
-        setQuestion(question)
-        setResolution(resolution)
-        setCategory(category)
 
         const winnerOutcomeData = isConditionResolved
           ? await conditionalTokens.getWinnerOutcome(conditionId)
           : null
-        setWinnerOutcome(winnerOutcomeData)
 
         const [
           userShares,
@@ -89,7 +85,6 @@ export const useMarketMakerData = (
         const actualPrices = MarketMakerService.getActualPrice(marketMakerShares)
 
         const token = getTokenFromAddress(context.networkId, collateralAddress)
-        setCollateral(token)
 
         const probabilityForYes = actualPrices.actualPriceForYes * 100
         const probabilityForNo = actualPrices.actualPriceForNo * 100
@@ -116,13 +111,19 @@ export const useMarketMakerData = (
         const poolSharesTotalSupply = await marketMaker.poolSharesTotalSupply()
         const userPoolShares = await marketMaker.poolSharesBalanceOf(user)
 
-        setTotalPoolShares(poolSharesTotalSupply)
-        setUserPoolShares(userPoolShares)
-
-        setMarketMakerFunding(marketMakerFund)
-        setMarketMakerUserFunding(marketMakerUserFund)
-
-        setBalance(balanceShares)
+        if (isSubscribed) {
+          setArbitrator(arbitratorObject)
+          setQuestion(question)
+          setResolution(resolution)
+          setCategory(category)
+          setWinnerOutcome(winnerOutcomeData)
+          setCollateral(token)
+          setTotalPoolShares(poolSharesTotalSupply)
+          setUserPoolShares(userPoolShares)
+          setMarketMakerFunding(marketMakerFund)
+          setMarketMakerUserFunding(marketMakerUserFund)
+          setBalance(balanceShares)
+        }
 
         enableStatus && setStatus(Status.Done)
       } catch (error) {
@@ -137,7 +138,10 @@ export const useMarketMakerData = (
       fetchMarketMakerData({ enableStatus: false })
     }, 2000)
 
-    return () => clearInterval(intervalId)
+    return () => {
+      clearInterval(intervalId)
+      isSubscribed = false
+    }
   }, [marketMakerAddress, context, conditionalTokens, winnerOutcome, realitio])
 
   return {

--- a/app/src/hooks/useMarkets.tsx
+++ b/app/src/hooks/useMarkets.tsx
@@ -20,6 +20,8 @@ export const useMarkets = (
   const [markets, setMarkets] = useState<MarketAndQuestion[]>([])
 
   useEffect(() => {
+    let isSubscribed = true
+
     const fetchMarkets = async () => {
       try {
         setStatus(Status.Loading)
@@ -59,7 +61,8 @@ export const useMarkets = (
           },
         )
 
-        setMarkets(marketsOrdered)
+        if (isSubscribed) setMarkets(marketsOrdered)
+
         setStatus(Status.Done)
       } catch (error) {
         logger.error('There was an error fetching the markets data:', error.message)
@@ -68,6 +71,9 @@ export const useMarkets = (
     }
 
     fetchMarkets()
+    return () => {
+      isSubscribed = false
+    }
   }, [context, marketMakerFactory, conditionalTokens, realitio])
 
   return {

--- a/app/src/hooks/useQuestion.tsx
+++ b/app/src/hooks/useQuestion.tsx
@@ -20,6 +20,7 @@ export const useQuestion = (
   const [category, setCategory] = useState<string>('')
 
   useEffect(() => {
+    let isSubscribed = true
     const fetchQuestion = async () => {
       try {
         const provider = context.library
@@ -32,16 +33,21 @@ export const useQuestion = (
           questionId,
         )
 
-        setQuestion(question)
-        setResolution(resolution)
-        setArbitratorAddress(arbitratorAddress)
-        setCategory(category)
+        if (isSubscribed) {
+          setQuestion(question)
+          setResolution(resolution)
+          setArbitratorAddress(arbitratorAddress)
+          setCategory(category)
+        }
       } catch (error) {
         logger.error('There was an error fetching the question data:', error.message)
       }
     }
 
     fetchQuestion()
+    return () => {
+      isSubscribed = false
+    }
   }, [marketMakerAddress, context, conditionalTokens, realitio])
 
   return { question, resolution, category, arbitratorAddress }


### PR DESCRIPTION
No issue related

Some component use promises, but never "unsubscribes" or cancel them. If for any reason, one component is unmounted before the promise resolves, our code will try to "set some state" on an unmounted component and this will throw a warning.

```
Warning: Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application.
To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```