### PR TITLE
Improve 3box signing

### DIFF
--- a/app/src/components/common/three_box_comments/index.tsx
+++ b/app/src/components/common/three_box_comments/index.tsx
@@ -145,7 +145,10 @@ export const ThreeBoxComments = (props: Props) => {
       logger.log(`Open three box with account ${account}`)
 
       const newBox = await Box.openBox(account, library._web3Provider)
-      await newBox.openSpace(THREEBOX_SPACE_NAME)
+      const spaceData = await Box.getSpace(account, THREEBOX_SPACE_NAME)
+      if (Object.keys(spaceData).length === 0) {
+        await newBox.openSpace(THREEBOX_SPACE_NAME)
+      }
       setCurrentUserAddress(account)
 
       newBox.onSyncDone(() => {


### PR DESCRIPTION
No issue related

Improve 3box signing, with this we only need one signing to view/update the user profile, and only another one when the user want to comment the market.

#### User signing to update/view the profile
![Screenshot_20191112_161843](https://user-images.githubusercontent.com/1144028/68703119-b636be00-0568-11ea-8e06-4c05e3dd7a21.png)

#### Open space to write a comment
![Screenshot_20191112_161907](https://user-images.githubusercontent.com/1144028/68703120-b636be00-0568-11ea-9dd4-296520663def.png)


3box keeps the data in the localstorage, so will only be requested once
![Screenshot_20191112_160417](https://user-images.githubusercontent.com/1144028/68703253-031a9480-0569-11ea-9d3b-d922682cdaea.png)

Also I added a validation to check if the space already exist