### PR TITLE
Rename "Home" to "Markets overview"

### DIFF
--- a/app/src/components/common/main_menu/index.tsx
+++ b/app/src/components/common/main_menu/index.tsx
@@ -27,7 +27,7 @@ export const MainMenu: React.FC = props => {
   return (
     <MainMenuWrapper {...restProps}>
       <Item activeClassName="active" to="/home">
-        Home
+        Markets Overview
       </Item>
       <ConnectedWeb3>
         <Item activeClassName="active" to="/create">

--- a/app/src/components/common/main_menu/index.tsx
+++ b/app/src/components/common/main_menu/index.tsx
@@ -26,7 +26,7 @@ export const MainMenu: React.FC = props => {
 
   return (
     <MainMenuWrapper {...restProps}>
-      <Item activeClassName="active" to="/home">
+      <Item activeClassName="active" to="/">
         Markets Overview
       </Item>
       <ConnectedWeb3>


### PR DESCRIPTION
Small change:  rename “HOME” to “MARKETS OVERVIEW”, and remove "home" string in link
