### PR TITLE
Show timezone in the resolution date input when creating new markets

### DIFF
--- a/app/src/components/common/date_field/index.tsx
+++ b/app/src/components/common/date_field/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
-import { IconCalendar } from './img/IconCalendar'
 import DatePicker from 'react-datepicker'
+import moment from 'moment'
+
+import { IconCalendar } from './img/IconCalendar'
 
 interface Props {
   disabled?: boolean
@@ -52,11 +54,7 @@ const DateFieldWrapper = styled.div<{ disabled?: boolean }>`
 
 export const DateField = (props: Props) => {
   const { onChange, selected, minDate, name, disabled, ...restProps } = props
-
-  const today = new Date()
-  const offset = (-1 * today.getTimezoneOffset()) / 60
-  const offsetName = 'UTC' + (offset >= 0 ? '+' + offset : offset)
-  const timeInputLabel = `Time (${offsetName})`
+  const timeInputLabel = `Time (UTC ${moment().format('Z')})`
 
   return (
     <DateFieldWrapper {...restProps} disabled={disabled}>

--- a/app/src/components/common/date_field/index.tsx
+++ b/app/src/components/common/date_field/index.tsx
@@ -54,7 +54,7 @@ const DateFieldWrapper = styled.div<{ disabled?: boolean }>`
 
 export const DateField = (props: Props) => {
   const { onChange, selected, minDate, name, disabled, ...restProps } = props
-  const timeInputLabel = `Time (UTC ${moment().format('Z')})`
+  const timeInputLabel = `Time (UTC${moment().format('Z')})`
 
   return (
     <DateFieldWrapper {...restProps} disabled={disabled}>

--- a/app/src/components/common/date_field/index.tsx
+++ b/app/src/components/common/date_field/index.tsx
@@ -53,6 +53,11 @@ const DateFieldWrapper = styled.div<{ disabled?: boolean }>`
 export const DateField = (props: Props) => {
   const { onChange, selected, minDate, name, disabled, ...restProps } = props
 
+  const today = new Date()
+  const offset = (-1 * today.getTimezoneOffset()) / 60
+  const offsetName = 'UTC' + (offset >= 0 ? '+' + offset : offset)
+  const timeInputLabel = `Time (${offsetName})`
+
   return (
     <DateFieldWrapper {...restProps} disabled={disabled}>
       <DatePicker
@@ -64,6 +69,7 @@ export const DateField = (props: Props) => {
         placeholderText="Pick a date..."
         selected={selected}
         showDisabledMonthNavigation
+        timeInputLabel={timeInputLabel}
         showTimeInput
       />
       <IconCalendar />


### PR DESCRIPTION
Closes #281 

I create a market with the timezone from Phoenix Arizona ( UTC - 7 )
This is the screenshot ...
![Screenshot_20191219_090634](https://user-images.githubusercontent.com/1144028/71189595-d5102a80-2261-11ea-97ef-7a671ddae734.png)

And this is how it looks in the market profile ...
![Screenshot_20191219_090743](https://user-images.githubusercontent.com/1144028/71189596-d5102a80-2261-11ea-8c10-c6c365f1db29.png)

And this is the market profile with Buenos Aires timezone
![Screenshot_20191219_130916](https://user-images.githubusercontent.com/1144028/71189598-d5a8c100-2261-11ea-94aa-928d5bd3083e.png)

The difference between the timezones is four (4) and in the market profile is OK for the buenos aires timezone.