### PR TITLE
(Feature) update summary confirm page

### DIFF
--- a/app/src/components/common/outcome_table/__snapshots__/index.spec.tsx.snap
+++ b/app/src/components/common/outcome_table/__snapshots__/index.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`should accept a selected outcome 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cDoURO"
+    class="sc-bdVaJa jFUYii"
   >
     <table
-      class="sc-cSHVUG cUnUqJ sc-bwzfXH jwzwsZ"
+      class="sc-cSHVUG cUnUqJ sc-bwzfXH gHdRWs"
     >
       <thead
         class="sc-htpNat KtFsv"
@@ -15,30 +15,30 @@ exports[`should accept a selected outcome 1`] = `
           class="sc-bxivhb gowuVX"
         >
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           />
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           >
             Outcome probabilities
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Current Price
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Shares
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Payout
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Price after trade
           </th>
@@ -280,10 +280,10 @@ exports[`should accept a selected outcome 1`] = `
 exports[`should hide radio selections 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cDoURO"
+    class="sc-bdVaJa jFUYii"
   >
     <table
-      class="sc-cSHVUG cUnUqJ sc-bwzfXH jwzwsZ"
+      class="sc-cSHVUG cUnUqJ sc-bwzfXH gHdRWs"
     >
       <thead
         class="sc-htpNat KtFsv"
@@ -292,27 +292,27 @@ exports[`should hide radio selections 1`] = `
           class="sc-bxivhb gowuVX"
         >
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           >
             Outcome probabilities
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Current Price
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Shares
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Payout
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Price after trade
           </th>
@@ -460,10 +460,10 @@ exports[`should hide radio selections 1`] = `
 exports[`should show no as winning token 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cDoURO"
+    class="sc-bdVaJa jFUYii"
   >
     <table
-      class="sc-cSHVUG cUnUqJ sc-bwzfXH jwzwsZ"
+      class="sc-cSHVUG cUnUqJ sc-bwzfXH gHdRWs"
     >
       <thead
         class="sc-htpNat KtFsv"
@@ -472,30 +472,30 @@ exports[`should show no as winning token 1`] = `
           class="sc-bxivhb gowuVX"
         >
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           />
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           >
             Outcome probabilities
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Current Price
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Shares
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Payout
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Price after trade
           </th>
@@ -655,10 +655,10 @@ exports[`should show no as winning token 1`] = `
 exports[`should show prices after trade 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cDoURO"
+    class="sc-bdVaJa jFUYii"
   >
     <table
-      class="sc-cSHVUG cUnUqJ sc-bwzfXH jwzwsZ"
+      class="sc-cSHVUG cUnUqJ sc-bwzfXH gHdRWs"
     >
       <thead
         class="sc-htpNat KtFsv"
@@ -667,30 +667,30 @@ exports[`should show prices after trade 1`] = `
           class="sc-bxivhb gowuVX"
         >
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           />
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           >
             Outcome probabilities
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Current Price
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Shares
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Payout
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Price after trade
           </th>
@@ -924,10 +924,10 @@ exports[`should show prices after trade 1`] = `
 exports[`should show yes as winning token 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cDoURO"
+    class="sc-bdVaJa jFUYii"
   >
     <table
-      class="sc-cSHVUG cUnUqJ sc-bwzfXH jwzwsZ"
+      class="sc-cSHVUG cUnUqJ sc-bwzfXH gHdRWs"
     >
       <thead
         class="sc-htpNat KtFsv"
@@ -936,30 +936,30 @@ exports[`should show yes as winning token 1`] = `
           class="sc-bxivhb gowuVX"
         >
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           />
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           >
             Outcome probabilities
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Current Price
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Shares
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Payout
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Price after trade
           </th>
@@ -1119,10 +1119,10 @@ exports[`should show yes as winning token 1`] = `
 exports[`should work with disabled columns 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cDoURO"
+    class="sc-bdVaJa jFUYii"
   >
     <table
-      class="sc-cSHVUG cUnUqJ sc-bwzfXH jwzwsZ"
+      class="sc-cSHVUG cUnUqJ sc-bwzfXH gHdRWs"
     >
       <thead
         class="sc-htpNat KtFsv"
@@ -1131,25 +1131,25 @@ exports[`should work with disabled columns 1`] = `
           class="sc-bxivhb gowuVX"
         >
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           />
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           >
             Outcome probabilities
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Current Price
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Shares
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Price after trade
           </th>
@@ -1373,10 +1373,10 @@ exports[`should work with disabled columns 1`] = `
 exports[`should work with minimal props 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cDoURO"
+    class="sc-bdVaJa jFUYii"
   >
     <table
-      class="sc-cSHVUG cUnUqJ sc-bwzfXH jwzwsZ"
+      class="sc-cSHVUG cUnUqJ sc-bwzfXH gHdRWs"
     >
       <thead
         class="sc-htpNat KtFsv"
@@ -1385,30 +1385,30 @@ exports[`should work with minimal props 1`] = `
           class="sc-bxivhb gowuVX"
         >
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           />
           <th
-            class="sc-ifAKCX ceeJPY"
+            class="sc-ifAKCX giynAj"
           >
             Outcome probabilities
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Current Price
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Shares
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Payout
           </th>
           <th
-            class="sc-ifAKCX bourab"
+            class="sc-ifAKCX ipPSVf"
           >
             Price after trade
           </th>

--- a/app/src/components/common/table/index.tsx
+++ b/app/src/components/common/table/index.tsx
@@ -2,10 +2,27 @@ import React, { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { TableOverflow } from '../table_overflow'
 
-const TableWrapper = styled.table`
+const TableWrapper = styled.table<{ stickyHeader?: boolean }>`
   border: none;
   margin: 0;
+  position: relative;
   width: 100%;
+
+  th {
+    background-color: #fff;
+    position: ${props => (props.stickyHeader ? 'sticky' : 'relative')};
+    top: 0;
+
+    &::before {
+      background-color: ${props => props.theme.borders.borderColor};
+      bottom: 0;
+      content: '';
+      height: 1px;
+      left: 0;
+      position: absolute;
+      right: 0;
+    }
+  }
 `
 
 export const THead = styled.thead``
@@ -24,10 +41,7 @@ export const TR = styled.tr`
 `
 
 export const TH = styled.th<{ textAlign?: string }>`
-  border-bottom: solid 1px #d5d5d5;
-  border-left: none;
-  border-right: none;
-  border-top: none;
+  border: none;
   color: #999;
   font-size: 12px;
   font-weight: 500;
@@ -61,16 +75,18 @@ TD.defaultProps = {
 export const TBody = styled.tbody``
 
 interface Props extends HTMLAttributes<HTMLTableElement> {
-  head?: React.ReactNode
   children: React.ReactNode
+  head?: React.ReactNode
+  maxHeight?: string
 }
 
 export const Table: React.FC<Props> = (props: Props) => {
-  const { head, children, ...restProps } = props
+  const { head, children, maxHeight, ...restProps } = props
+  const stickyHeader: boolean = maxHeight ? true : false
 
   return (
-    <TableOverflow>
-      <TableWrapper {...restProps}>
+    <TableOverflow maxHeight={maxHeight}>
+      <TableWrapper stickyHeader={stickyHeader} {...restProps}>
         {head ? head : null}
         <TBody>{children}</TBody>
       </TableWrapper>

--- a/app/src/components/common/table_overflow/index.tsx
+++ b/app/src/components/common/table_overflow/index.tsx
@@ -1,13 +1,15 @@
 import React, { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
-const TableOverflowWrapper = styled.div`
+const TableOverflowWrapper = styled.div<{ maxHeight?: string }>`
   overflow-x: auto;
+  max-height: ${props => (props.maxHeight ? props.maxHeight : 'none')};
   width: 100%;
 `
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
+  maxHeight?: string
 }
 
 export const TableOverflow: React.FC<Props> = (props: Props) => {

--- a/app/src/components/market/steps/items/create_market_step.tsx
+++ b/app/src/components/market/steps/items/create_market_step.tsx
@@ -23,10 +23,6 @@ const ButtonLinkStyled = styled(ButtonLink)`
   margin-right: auto;
 `
 
-const TableStyled = styled(Table)`
-  margin-bottom: 25px;
-`
-
 const Grid = styled.div`
   display: grid;
   grid-column-gap: 20px;
@@ -111,7 +107,7 @@ const CreateMarketStep = (props: Props) => {
         )}
       </Grid>
       <SubsectionTitle>Outcomes</SubsectionTitle>
-      <TableStyled
+      <Table
         head={
           <THead>
             <TR>
@@ -130,7 +126,7 @@ const CreateMarketStep = (props: Props) => {
             </TR>
           )
         })}
-      </TableStyled>
+      </Table>
       {questionId || marketMakerAddress ? (
         <>
           <SubsectionTitle>Created Market Information</SubsectionTitle>

--- a/app/src/components/market/steps/items/create_market_step.tsx
+++ b/app/src/components/market/steps/items/create_market_step.tsx
@@ -120,6 +120,7 @@ const CreateMarketStep = (props: Props) => {
             </TR>
           </THead>
         }
+        maxHeight="130px"
       >
         {outcomes.map((outcome, index) => {
           return (

--- a/app/src/components/market/steps/items/summary_market_step.tsx
+++ b/app/src/components/market/steps/items/summary_market_step.tsx
@@ -107,6 +107,7 @@ const SummaryMarketStep = (props: Props) => {
               </TR>
             </THead>
           }
+          maxHeight="130px"
         >
           {balances.map((item, index) => {
             return (

--- a/app/src/components/market/steps/items/summary_market_step.tsx
+++ b/app/src/components/market/steps/items/summary_market_step.tsx
@@ -18,10 +18,6 @@ import { NavLink } from 'react-router-dom'
 import { DisplayArbitrator } from '../../../common/display_arbitrator'
 import { ButtonAnchor } from '../../../common/button_anchor'
 
-const TableStyled = styled(Table)`
-  margin-bottom: 25px;
-`
-
 const NavLinkStyled = styled(NavLink)`
   color: ${props => props.theme.colors.textColor};
   text-decoration: underline;
@@ -98,7 +94,7 @@ const SummaryMarketStep = (props: Props) => {
           />
         </Grid>
         <SubsectionTitle>Outcomes</SubsectionTitle>
-        <TableStyled
+        <Table
           head={
             <THead>
               <TR>
@@ -117,7 +113,7 @@ const SummaryMarketStep = (props: Props) => {
               </TR>
             )
           })}
-        </TableStyled>
+        </Table>
         <ButtonContainer>
           <Button rel="noopener noreferrer" href={`/#/${marketMakerAddress}`} target="_blank">
             View Market


### PR DESCRIPTION
Don't merge this before #272 

Closes #216 
Closes #217

There are a lot of PRs depending on #272, so... here's a new one.

It should limit the height of the tables containing more than two items on the Summary and Create sections.

Designs: https://zpl.io/Vq5dxzJ and https://zpl.io/bJ0MZqx

![Dec-19-2019 16-48-27](https://user-images.githubusercontent.com/4015436/71207567-ee2ad280-2285-11ea-82d8-ab525d6e3f2c.gif)
