### PR TITLE
Show price after trade by adjusting the probability bars

### DIFF
--- a/app/src/components/common/bar_diagram_probabilities/index.tsx
+++ b/app/src/components/common/bar_diagram_probabilities/index.tsx
@@ -94,7 +94,7 @@ const BarDiagramComponent: React.FC<Props> = (props: Props) => {
       <Outcome>
         <OutcomeText>
           <OutcomeName>{outcomeName}</OutcomeName>
-          <OutcomeValue>{probability}%</OutcomeValue>
+          <OutcomeValue>{probability.toFixed(2)}%</OutcomeValue>
         </OutcomeText>
         <ProgressBar>
           <Progress color={progressColor} width={probability} />

--- a/app/src/components/common/bar_diagram_probabilities/index.tsx
+++ b/app/src/components/common/bar_diagram_probabilities/index.tsx
@@ -68,6 +68,7 @@ const Progress = styled.div<ProgressBarProps>`
   border-radius: 3px;
   height: 100%;
   width: ${props => props.width}%;
+  transition: width 1s;
 `
 
 interface Props extends HTMLAttributes<HTMLButtonElement> {

--- a/app/src/components/common/outcome_table/__snapshots__/index.spec.tsx.snap
+++ b/app/src/components/common/outcome_table/__snapshots__/index.spec.tsx.snap
@@ -41,12 +41,6 @@ exports[`should accept a selected outcome 1`] = `
             >
               Payout
             </th>
-            <th
-              class="sc-ifAKCX ipPSVf"
-              colspan="1"
-            >
-              Price after trade
-            </th>
           </tr>
         </thead>
         <tbody
@@ -129,7 +123,7 @@ exports[`should accept a selected outcome 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -154,14 +148,6 @@ exports[`should accept a selected outcome 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
           <tr
@@ -233,7 +219,7 @@ exports[`should accept a selected outcome 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -258,14 +244,6 @@ exports[`should accept a selected outcome 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
         </tbody>
@@ -316,12 +294,6 @@ exports[`should hide radio selections 1`] = `
             >
               Payout
             </th>
-            <th
-              class="sc-ifAKCX ipPSVf"
-              colspan="1"
-            >
-              Price after trade
-            </th>
           </tr>
         </thead>
         <tbody
@@ -357,7 +329,7 @@ exports[`should hide radio selections 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -382,14 +354,6 @@ exports[`should hide radio selections 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
           <tr
@@ -422,7 +386,7 @@ exports[`should hide radio selections 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -447,14 +411,6 @@ exports[`should hide radio selections 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
         </tbody>
@@ -505,12 +461,6 @@ exports[`should show no as winning token 1`] = `
             >
               Payout
             </th>
-            <th
-              class="sc-ifAKCX ipPSVf"
-              colspan="1"
-            >
-              Price after trade
-            </th>
           </tr>
         </thead>
         <tbody
@@ -555,7 +505,7 @@ exports[`should show no as winning token 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -580,14 +530,6 @@ exports[`should show no as winning token 1`] = `
               class="sc-EHOje sc-kAzzGY foKdFt"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje sc-kAzzGY foKdFt"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
           <tr
@@ -623,7 +565,7 @@ exports[`should show no as winning token 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -649,14 +591,6 @@ exports[`should show no as winning token 1`] = `
             >
               0.00
             </td>
-            <td
-              class="sc-EHOje sc-kAzzGY CGYbl"
-            >
-               
-              <strong>
-                DAI
-              </strong>
-            </td>
           </tr>
         </tbody>
       </table>
@@ -665,7 +599,7 @@ exports[`should show no as winning token 1`] = `
 </DocumentFragment>
 `;
 
-exports[`should show prices after trade 1`] = `
+exports[`should show probabilities 1`] = `
 <DocumentFragment>
   <div
     class="sc-cSHVUG cUnUqJ"
@@ -705,12 +639,6 @@ exports[`should show prices after trade 1`] = `
               colspan="1"
             >
               Payout
-            </th>
-            <th
-              class="sc-ifAKCX ipPSVf"
-              colspan="1"
-            >
-              Price after trade
             </th>
           </tr>
         </thead>
@@ -779,16 +707,16 @@ exports[`should show prices after trade 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      0.75%
                     </p>
                   </div>
                   <div
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
-                      color="#acacac"
-                      width="50"
+                      class="sc-jzJRlG ihXpTy"
+                      color="#00be95"
+                      width="0.75"
                     />
                   </div>
                 </div>
@@ -811,14 +739,6 @@ exports[`should show prices after trade 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-              0.7500 
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
           <tr
@@ -883,16 +803,16 @@ exports[`should show prices after trade 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      0.25%
                     </p>
                   </div>
                   <div
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG hupGLW"
                       color="#acacac"
-                      width="50"
+                      width="0.25"
                     />
                   </div>
                 </div>
@@ -915,14 +835,6 @@ exports[`should show prices after trade 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-              0.2500 
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
         </tbody>
@@ -973,12 +885,6 @@ exports[`should show yes as winning token 1`] = `
             >
               Payout
             </th>
-            <th
-              class="sc-ifAKCX ipPSVf"
-              colspan="1"
-            >
-              Price after trade
-            </th>
           </tr>
         </thead>
         <tbody
@@ -1023,7 +929,7 @@ exports[`should show yes as winning token 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -1048,14 +954,6 @@ exports[`should show yes as winning token 1`] = `
               class="sc-EHOje sc-kAzzGY foKdFt"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje sc-kAzzGY foKdFt"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
           <tr
@@ -1091,7 +989,7 @@ exports[`should show yes as winning token 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -1116,14 +1014,6 @@ exports[`should show yes as winning token 1`] = `
               class="sc-EHOje sc-kAzzGY CGYbl"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje sc-kAzzGY CGYbl"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
         </tbody>
@@ -1167,12 +1057,6 @@ exports[`should work with disabled columns 1`] = `
               colspan="1"
             >
               Shares
-            </th>
-            <th
-              class="sc-ifAKCX ipPSVf"
-              colspan="1"
-            >
-              Price after trade
             </th>
           </tr>
         </thead>
@@ -1248,7 +1132,7 @@ exports[`should work with disabled columns 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -1268,14 +1152,6 @@ exports[`should work with disabled columns 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
           <tr
@@ -1347,7 +1223,7 @@ exports[`should work with disabled columns 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -1367,14 +1243,6 @@ exports[`should work with disabled columns 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
         </tbody>
@@ -1425,12 +1293,6 @@ exports[`should work with minimal props 1`] = `
             >
               Payout
             </th>
-            <th
-              class="sc-ifAKCX ipPSVf"
-              colspan="1"
-            >
-              Price after trade
-            </th>
           </tr>
         </thead>
         <tbody
@@ -1505,7 +1367,7 @@ exports[`should work with minimal props 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -1530,14 +1392,6 @@ exports[`should work with minimal props 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
           <tr
@@ -1609,7 +1463,7 @@ exports[`should work with minimal props 1`] = `
                     class="sc-fjdhpX iZcRRn"
                   >
                     <div
-                      class="sc-jzJRlG ckyZEE"
+                      class="sc-jzJRlG dxyKLL"
                       color="#acacac"
                       width="50"
                     />
@@ -1634,14 +1488,6 @@ exports[`should work with minimal props 1`] = `
               class="sc-EHOje cxvido"
             >
               0.00
-            </td>
-            <td
-              class="sc-EHOje cxvido"
-            >
-               
-              <strong>
-                DAI
-              </strong>
             </td>
           </tr>
         </tbody>

--- a/app/src/components/common/outcome_table/__snapshots__/index.spec.tsx.snap
+++ b/app/src/components/common/outcome_table/__snapshots__/index.spec.tsx.snap
@@ -116,7 +116,7 @@ exports[`should accept a selected outcome 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -212,7 +212,7 @@ exports[`should accept a selected outcome 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -322,7 +322,7 @@ exports[`should hide radio selections 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -379,7 +379,7 @@ exports[`should hide radio selections 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -498,7 +498,7 @@ exports[`should show no as winning token 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -558,7 +558,7 @@ exports[`should show no as winning token 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -922,7 +922,7 @@ exports[`should show yes as winning token 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -982,7 +982,7 @@ exports[`should show yes as winning token 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -1125,7 +1125,7 @@ exports[`should work with disabled columns 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -1216,7 +1216,7 @@ exports[`should work with disabled columns 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -1360,7 +1360,7 @@ exports[`should work with minimal props 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div
@@ -1456,7 +1456,7 @@ exports[`should work with minimal props 1`] = `
                     <p
                       class="sc-jTzLTM hqAejy"
                     >
-                      50%
+                      50.00%
                     </p>
                   </div>
                   <div

--- a/app/src/components/common/outcome_table/index.spec.tsx
+++ b/app/src/components/common/outcome_table/index.spec.tsx
@@ -33,6 +33,8 @@ const getBalances = (yes: Partial<BalanceItem> = {}, no: Partial<BalanceItem> = 
   ]
 }
 
+const probabilities = [50, 50]
+
 const renderTable = (component: any) =>
   render(<ThemeProvider theme={theme}>{component}</ThemeProvider>)
 
@@ -45,7 +47,9 @@ const dai = {
 test('should work with minimal props', () => {
   const balances = getBalances()
 
-  const { asFragment } = renderTable(<OutcomeTable balances={balances} collateral={dai} />)
+  const { asFragment } = renderTable(
+    <OutcomeTable probabilities={probabilities} balances={balances} collateral={dai} />,
+  )
 
   expect(asFragment()).toMatchSnapshot()
 })
@@ -54,7 +58,12 @@ test('should hide radio selections', () => {
   const balances = getBalances()
 
   const { asFragment } = renderTable(
-    <OutcomeTable balances={balances} collateral={dai} displayRadioSelection={false} />,
+    <OutcomeTable
+      probabilities={probabilities}
+      balances={balances}
+      collateral={dai}
+      displayRadioSelection={false}
+    />,
   )
 
   expect(asFragment()).toMatchSnapshot()
@@ -65,6 +74,7 @@ test('should work with disabled columns', () => {
 
   const { asFragment } = renderTable(
     <OutcomeTable
+      probabilities={probabilities}
       balances={balances}
       collateral={dai}
       disabledColumns={[OutcomeTableValue.Payout]}
@@ -78,7 +88,12 @@ test('should show yes as winning token', () => {
   const balances = getBalances({ winningOutcome: true })
 
   const { asFragment } = renderTable(
-    <OutcomeTable balances={balances} collateral={dai} withWinningOutcome={true} />,
+    <OutcomeTable
+      probabilities={probabilities}
+      balances={balances}
+      collateral={dai}
+      withWinningOutcome={true}
+    />,
   )
 
   expect(asFragment()).toMatchSnapshot()
@@ -88,17 +103,22 @@ test('should show no as winning token', () => {
   const balances = getBalances({}, { winningOutcome: true })
 
   const { asFragment } = renderTable(
-    <OutcomeTable balances={balances} collateral={dai} withWinningOutcome={true} />,
+    <OutcomeTable
+      probabilities={probabilities}
+      balances={balances}
+      collateral={dai}
+      withWinningOutcome={true}
+    />,
   )
 
   expect(asFragment()).toMatchSnapshot()
 })
 
-test('should show prices after trade', () => {
+test('should show probabilities', () => {
   const balances = getBalances()
 
   const { asFragment } = renderTable(
-    <OutcomeTable balances={balances} collateral={dai} pricesAfterTrade={[0.75, 0.25]} />,
+    <OutcomeTable balances={balances} collateral={dai} probabilities={[0.75, 0.25]} />,
   )
 
   expect(asFragment()).toMatchSnapshot()
@@ -108,7 +128,12 @@ test('should accept a selected outcome', () => {
   const balances = getBalances()
 
   const { asFragment } = renderTable(
-    <OutcomeTable balances={balances} collateral={dai} outcomeSelected={0} />,
+    <OutcomeTable
+      probabilities={probabilities}
+      balances={balances}
+      collateral={dai}
+      outcomeSelected={0}
+    />,
   )
 
   expect(asFragment()).toMatchSnapshot()
@@ -120,7 +145,12 @@ test('should accept a selected outcome', () => {
   const onOutcomeChange = jest.fn()
 
   const { getByTestId } = renderTable(
-    <OutcomeTable balances={balances} collateral={dai} outcomeHandleChange={onOutcomeChange} />,
+    <OutcomeTable
+      probabilities={probabilities}
+      balances={balances}
+      collateral={dai}
+      outcomeHandleChange={onOutcomeChange}
+    />,
   )
 
   const radioForYesComponent = getByTestId('outcome_table_radio_Yes')

--- a/app/src/components/common/outcome_table/index.tsx
+++ b/app/src/components/common/outcome_table/index.tsx
@@ -10,7 +10,7 @@ import { BarDiagram } from '../bar_diagram_probabilities'
 interface Props {
   balances: BalanceItem[]
   collateral: Token
-  pricesAfterTrade?: number[]
+  probabilities: number[]
   outcomeSelected?: number
   outcomeHandleChange?: (e: number) => void
   disabledColumns?: OutcomeTableValue[]
@@ -41,7 +41,7 @@ export const OutcomeTable = (props: Props) => {
   const {
     balances,
     collateral,
-    pricesAfterTrade,
+    probabilities,
     outcomeSelected,
     outcomeHandleChange,
     disabledColumns = [],
@@ -54,16 +54,14 @@ export const OutcomeTable = (props: Props) => {
     OutcomeTableValue.CurrentPrice,
     OutcomeTableValue.Shares,
     OutcomeTableValue.Payout,
-    OutcomeTableValue.PriceAfterTrade,
   ]
 
-  const outcomeMaxProbability = balances.reduce(
-    (max, balance, index, balances) =>
-      balance.probability > balances[max].probability ? index : max,
+  const outcomeMaxProbability = probabilities.reduce(
+    (max, balance, index, balances) => (balance > balances[max] ? index : max),
     0,
   )
 
-  const equalProbabilities = balances.every(b => b.probability === balances[0].probability)
+  const equalProbabilities = probabilities.every(b => b === probabilities[0])
 
   const TableCellsAlign = ['left', 'right', 'right', 'right', 'right', 'right']
 
@@ -87,15 +85,13 @@ export const OutcomeTable = (props: Props) => {
     )
   }
 
-  const renderTableRow = (
-    balanceItem: BalanceItem,
-    outcomeIndex: number,
-    priceAfterTrade?: number,
-  ) => {
-    const { outcomeName, probability, currentPrice, shares, winningOutcome } = balanceItem
+  const renderTableRow = (balanceItem: BalanceItem, outcomeIndex: number) => {
+    const { outcomeName, currentPrice, shares, winningOutcome } = balanceItem
     const isWinning = !equalProbabilities && outcomeIndex === outcomeMaxProbability
 
     const currentPriceFormatted = Number(currentPrice).toFixed(4)
+
+    const probability = probabilities[outcomeIndex]
 
     return (
       <TR key={outcomeName}>
@@ -154,15 +150,6 @@ export const OutcomeTable = (props: Props) => {
         ) : (
           <TD textAlign={TableCellsAlign[4]}>{formatBigNumber(shares, collateral.decimals)}</TD>
         )}
-        {disabledColumns.includes(OutcomeTableValue.PriceAfterTrade) ? null : withWinningOutcome ? (
-          <TDStyled textAlign={TableCellsAlign[5]} winningOutcome={winningOutcome}>
-            {priceAfterTrade && priceAfterTrade.toFixed(4)} <strong>{collateral.symbol}</strong>
-          </TDStyled>
-        ) : (
-          <TD textAlign={TableCellsAlign[5]}>
-            {priceAfterTrade && priceAfterTrade.toFixed(4)} <strong>{collateral.symbol}</strong>
-          </TD>
-        )}
       </TR>
     )
   }
@@ -170,9 +157,7 @@ export const OutcomeTable = (props: Props) => {
   const renderTable = () =>
     balances
       .sort((a, b) => (a.winningOutcome === b.winningOutcome ? 0 : a.winningOutcome ? -1 : 1)) // Put winning outcome first
-      .map((balanceItem: BalanceItem, index) =>
-        renderTableRow(balanceItem, index, pricesAfterTrade && pricesAfterTrade[index]),
-      )
+      .map((balanceItem: BalanceItem, index) => renderTableRow(balanceItem, index))
 
   return (
     <TableWrapper>

--- a/app/src/components/common/outcome_table/index.tsx
+++ b/app/src/components/common/outcome_table/index.tsx
@@ -111,7 +111,7 @@ export const OutcomeTable = (props: Props) => {
             <BarDiagram
               outcomeName={outcomeName}
               isWinning={isWinning}
-              probability={probability}
+              probability={+probability.toFixed(2)}
               withWinningOutcome={withWinningOutcome}
               winningOutcome={winningOutcome}
             />
@@ -121,7 +121,7 @@ export const OutcomeTable = (props: Props) => {
             <BarDiagram
               outcomeName={outcomeName}
               isWinning={isWinning}
-              probability={probability}
+              probability={+probability.toFixed(2)}
               withWinningOutcome={withWinningOutcome}
               winningOutcome={winningOutcome}
             />

--- a/app/src/components/common/outcome_table/index.tsx
+++ b/app/src/components/common/outcome_table/index.tsx
@@ -111,7 +111,7 @@ export const OutcomeTable = (props: Props) => {
             <BarDiagram
               outcomeName={outcomeName}
               isWinning={isWinning}
-              probability={+probability.toFixed(2)}
+              probability={probability}
               withWinningOutcome={withWinningOutcome}
               winningOutcome={winningOutcome}
             />
@@ -121,7 +121,7 @@ export const OutcomeTable = (props: Props) => {
             <BarDiagram
               outcomeName={outcomeName}
               isWinning={isWinning}
-              probability={+probability.toFixed(2)}
+              probability={probability}
               withWinningOutcome={withWinningOutcome}
               winningOutcome={winningOutcome}
             />

--- a/app/src/components/market/market_buy.tsx
+++ b/app/src/components/market/market_buy.tsx
@@ -95,12 +95,17 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
       )
       const pricesAfterTrade = MarketMakerService.getActualPrice(balanceAfterTrade)
 
-      return [tradedShares, pricesAfterTrade]
+      const probabilities = pricesAfterTrade.map(priceAfterTrade => {
+        const probabilityForPrice = priceAfterTrade * 100
+        return Math.round((probabilityForPrice / 100) * 100)
+      })
+
+      return [tradedShares, probabilities]
     },
     [balances, marketMakerService, outcomeIndex],
   )
 
-  const [tradedShares, pricesAfterTrade] = useAsyncDerivedValue(
+  const [tradedShares, probabilities] = useAsyncDerivedValue(
     amount,
     [new BigNumber(0), balances.map(() => 0)],
     calcBuyAmount,
@@ -173,7 +178,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
         <OutcomeTable
           balances={balances}
           collateral={collateral}
-          pricesAfterTrade={pricesAfterTrade}
+          probabilities={probabilities}
           outcomeSelected={outcomeIndex}
           outcomeHandleChange={(value: number) => setOutcomeIndex(value)}
           disabledColumns={[OutcomeTableValue.Payout]}

--- a/app/src/components/market/market_buy.tsx
+++ b/app/src/components/market/market_buy.tsx
@@ -95,10 +95,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
       )
       const pricesAfterTrade = MarketMakerService.getActualPrice(balanceAfterTrade)
 
-      const probabilities = pricesAfterTrade.map(priceAfterTrade => {
-        const probabilityForPrice = priceAfterTrade * 100
-        return Math.round(probabilityForPrice)
-      })
+      const probabilities = pricesAfterTrade.map(priceAfterTrade => priceAfterTrade * 100)
 
       return [tradedShares, probabilities]
     },

--- a/app/src/components/market/market_buy.tsx
+++ b/app/src/components/market/market_buy.tsx
@@ -97,7 +97,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
 
       const probabilities = pricesAfterTrade.map(priceAfterTrade => {
         const probabilityForPrice = priceAfterTrade * 100
-        return Math.round((probabilityForPrice / 100) * 100)
+        return Math.round(probabilityForPrice)
       })
 
       return [tradedShares, probabilities]

--- a/app/src/components/market/market_fund.tsx
+++ b/app/src/components/market/market_fund.tsx
@@ -163,7 +163,7 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
     ? `You don't have enough collateral in your balance.`
     : ''
 
-  const probabilities = balances.map(balance => Math.round((balance.probability / 100) * 100))
+  const probabilities = balances.map(balance => Math.round(balance.probability))
 
   return (
     <>

--- a/app/src/components/market/market_fund.tsx
+++ b/app/src/components/market/market_fund.tsx
@@ -163,6 +163,8 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
     ? `You don't have enough collateral in your balance.`
     : ''
 
+  const probabilities = balances.map(balance => Math.round((balance.probability / 100) * 100))
+
   return (
     <>
       <SectionTitle title={question} subTitle={resolution ? formatDate(resolution) : ''} />
@@ -170,13 +172,10 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
         <SubsectionTitleStyled>Fund this market</SubsectionTitleStyled>
         <OutcomeTable
           balances={balances}
-          disabledColumns={[
-            OutcomeTableValue.CurrentPrice,
-            OutcomeTableValue.Payout,
-            OutcomeTableValue.PriceAfterTrade,
-          ]}
+          disabledColumns={[OutcomeTableValue.CurrentPrice, OutcomeTableValue.Payout]}
           displayRadioSelection={false}
           collateral={collateral}
+          probabilities={probabilities}
         />
         <AmountWrapper
           formField={

--- a/app/src/components/market/market_fund.tsx
+++ b/app/src/components/market/market_fund.tsx
@@ -163,7 +163,7 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
     ? `You don't have enough collateral in your balance.`
     : ''
 
-  const probabilities = balances.map(balance => Math.round(balance.probability))
+  const probabilities = balances.map(balance => balance.probability)
 
   return (
     <>

--- a/app/src/components/market/market_sell.tsx
+++ b/app/src/components/market/market_sell.tsx
@@ -123,10 +123,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
       const pricesAfterTrade = MarketMakerService.getActualPrice(balanceAfterTrade)
       const costFee = mulBN(amountToSell, marketFeeWithTwoDecimals)
 
-      const probabilities = pricesAfterTrade.map(priceAfterTrade => {
-        const probabilityForPrice = priceAfterTrade * 100
-        return Math.round(probabilityForPrice)
-      })
+      const probabilities = pricesAfterTrade.map(priceAfterTrade => priceAfterTrade * 100)
 
       return [probabilities, costFee, amountToSell]
     },

--- a/app/src/components/market/market_sell.tsx
+++ b/app/src/components/market/market_sell.tsx
@@ -125,7 +125,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
 
       const probabilities = pricesAfterTrade.map(priceAfterTrade => {
         const probabilityForPrice = priceAfterTrade * 100
-        return Math.round((probabilityForPrice / 100) * 100)
+        return Math.round(probabilityForPrice)
       })
 
       return [probabilities, costFee, amountToSell]

--- a/app/src/components/market/profile/closed_market_detail.tsx
+++ b/app/src/components/market/profile/closed_market_detail.tsx
@@ -128,7 +128,7 @@ export const ClosedMarketDetailWrapper = (props: Props) => {
   const resolutionFormat = resolution ? formatDate(resolution) : ''
   const winningOutcome = balances.find((balanceItem: BalanceItem) => balanceItem.winningOutcome)
 
-  const probabilities = balances.map(balance => Math.round(balance.probability))
+  const probabilities = balances.map(balance => balance.probability)
 
   return (
     <>

--- a/app/src/components/market/profile/closed_market_detail.tsx
+++ b/app/src/components/market/profile/closed_market_detail.tsx
@@ -128,6 +128,8 @@ export const ClosedMarketDetailWrapper = (props: Props) => {
   const resolutionFormat = resolution ? formatDate(resolution) : ''
   const winningOutcome = balances.find((balanceItem: BalanceItem) => balanceItem.winningOutcome)
 
+  const probabilities = balances.map(balance => Math.round((balance.probability / 100) * 100))
+
   return (
     <>
       <ClosedMarket date={resolutionFormat} />
@@ -136,9 +138,10 @@ export const ClosedMarketDetailWrapper = (props: Props) => {
         <OutcomeTable
           balances={balances}
           collateral={collateralToken}
-          disabledColumns={[OutcomeTableValue.CurrentPrice, OutcomeTableValue.PriceAfterTrade]}
+          disabledColumns={[OutcomeTableValue.CurrentPrice]}
           withWinningOutcome={true}
           displayRadioSelection={false}
+          probabilities={probabilities}
         />
 
         <SubsectionTitle>Details</SubsectionTitle>

--- a/app/src/components/market/profile/closed_market_detail.tsx
+++ b/app/src/components/market/profile/closed_market_detail.tsx
@@ -128,7 +128,7 @@ export const ClosedMarketDetailWrapper = (props: Props) => {
   const resolutionFormat = resolution ? formatDate(resolution) : ''
   const winningOutcome = balances.find((balanceItem: BalanceItem) => balanceItem.winningOutcome)
 
-  const probabilities = balances.map(balance => Math.round((balance.probability / 100) * 100))
+  const probabilities = balances.map(balance => Math.round(balance.probability))
 
   return (
     <>

--- a/app/src/components/market/profile/view.tsx
+++ b/app/src/components/market/profile/view.tsx
@@ -46,7 +46,7 @@ const ViewWrapper = (props: Props) => {
     return !shares.isZero()
   })
 
-  const probabilities = balances.map(balance => Math.round(balance.probability))
+  const probabilities = balances.map(balance => balance.probability)
 
   const renderTableData = () => {
     const disabledColumns = [OutcomeTableValue.Payout]

--- a/app/src/components/market/profile/view.tsx
+++ b/app/src/components/market/profile/view.tsx
@@ -46,7 +46,7 @@ const ViewWrapper = (props: Props) => {
     return !shares.isZero()
   })
 
-  const probabilities = balances.map(balance => Math.round((balance.probability / 100) * 100))
+  const probabilities = balances.map(balance => Math.round(balance.probability))
 
   const renderTableData = () => {
     const disabledColumns = [OutcomeTableValue.Payout]

--- a/app/src/components/market/profile/view.tsx
+++ b/app/src/components/market/profile/view.tsx
@@ -46,8 +46,10 @@ const ViewWrapper = (props: Props) => {
     return !shares.isZero()
   })
 
+  const probabilities = balances.map(balance => Math.round((balance.probability / 100) * 100))
+
   const renderTableData = () => {
-    const disabledColumns = [OutcomeTableValue.Payout, OutcomeTableValue.PriceAfterTrade]
+    const disabledColumns = [OutcomeTableValue.Payout]
     if (!userHasShares) {
       disabledColumns.push(OutcomeTableValue.Shares)
     }
@@ -57,6 +59,7 @@ const ViewWrapper = (props: Props) => {
         collateral={collateral}
         displayRadioSelection={false}
         disabledColumns={disabledColumns}
+        probabilities={probabilities}
       />
     )
   }

--- a/app/src/hooks/useMarketMakerData.tsx
+++ b/app/src/hooks/useMarketMakerData.tsx
@@ -110,8 +110,7 @@ export const useMarketMakerData = (
 
     const balances: BalanceItem[] = outcomes.map((outcome: string, index: number) => {
       const outcomeName = outcome
-      const probabilityForPrice = actualPrices[index] * 100
-      const probability = Math.round((probabilityForPrice / 100) * 100)
+      const probability = actualPrices[index] * 100
       const currentPrice = actualPrices[index]
       const shares = userShares[index]
       const holdings = marketMakerShares[index]

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -58,7 +58,6 @@ export enum OutcomeTableValue {
   CurrentPrice = 'Current Price',
   Shares = 'Shares',
   Payout = 'Payout',
-  PriceAfterTrade = 'Price after trade',
 }
 
 export interface Token {


### PR DESCRIPTION
closes #310 

### Includes
- Remove price after trade column
- Adjust probabilities regarding amount enter by the user
- Update tests

You can see a demo of the feature right here

https://www.loom.com/share/977daed6a7974767ba66064bdd21df76

@gabitoesmiapodo please check if the transition is OK for you