### PR TITLE
Choose how much funding user can remove

### DIFF
--- a/app/src/components/common/balance_shares/index.tsx
+++ b/app/src/components/common/balance_shares/index.tsx
@@ -2,14 +2,15 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { formatBigNumber } from '../../../util/tools'
-import { BalanceItem, Token } from '../../../util/types'
+import { Token } from '../../../util/types'
 import { FormRowNote } from '../form_row_note'
 import { FormRowLink } from '../form_row_link'
+import { BigNumber } from 'ethers/utils'
 
 interface Props {
-  balanceItem?: BalanceItem
+  shares: BigNumber
   collateral: Token
-  onClickMax: (balanceItem?: BalanceItem) => void
+  onClickMax: (shares: BigNumber) => void
 }
 
 const Wrapper = styled.div`
@@ -28,21 +29,14 @@ const Note = styled(FormRowNote)`
 `
 
 export const BalanceShares = (props: Props) => {
-  const { balanceItem, collateral, onClickMax } = props
-  const sharesBalanceFormatted = balanceItem
-    ? formatBigNumber(balanceItem.shares, collateral.decimals)
-    : ''
+  const { shares, collateral, onClickMax } = props
 
   return (
-    <>
-      {sharesBalanceFormatted && (
-        <Wrapper>
-          <Note>
-            Balance <strong>{sharesBalanceFormatted}</strong>
-          </Note>
-          <FormRowLink onClick={() => onClickMax(balanceItem)}>Add all funds</FormRowLink>
-        </Wrapper>
-      )}
-    </>
+    <Wrapper>
+      <Note>
+        Current Balance <strong>{formatBigNumber(shares, collateral.decimals)} shares</strong>
+      </Note>
+      <FormRowLink onClick={() => onClickMax(shares)}>Add all shares</FormRowLink>
+    </Wrapper>
   )
 }

--- a/app/src/components/market/market_fund.tsx
+++ b/app/src/components/market/market_fund.tsx
@@ -91,7 +91,7 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
   const { buildMarketMaker } = useContracts(context)
   const marketMaker = buildMarketMaker(marketMakerAddress)
 
-  const [amount, setAmount] = useState<BigNumber>(new BigNumber(0))
+  const [amountToFund, setAmountToFund] = useState<BigNumber>(new BigNumber(0))
   const [status, setStatus] = useState<Status>(Status.Ready)
   const [message, setMessage] = useState<string>('')
 
@@ -110,7 +110,7 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
 
       setStatus(Status.Loading)
       setMessage(
-        `Add funding amount: ${formatBigNumber(amount, collateral.decimals)} ${
+        `Add funding amount: ${formatBigNumber(amountToFund, collateral.decimals)} ${
           collateral.symbol
         } ...`,
       )
@@ -123,7 +123,7 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
       const hasEnoughAlowance = await collateralService.hasEnoughAllowance(
         account,
         cpk.address,
-        amount,
+        amountToFund,
       )
 
       if (!hasEnoughAlowance) {
@@ -131,13 +131,13 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
       }
 
       await cpk.addFunding({
-        amount,
+        amount: amountToFund,
         collateral,
         marketMaker,
       })
 
       setStatus(Status.Ready)
-      setAmount(new BigNumber(0))
+      setAmountToFund(new BigNumber(0))
     } catch (err) {
       setStatus(Status.Error)
       logger.log(`Error trying to add funding: ${err.message}`)
@@ -171,8 +171,8 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
 
   const collateralBalance = useCollateralBalance(collateral, context)
 
-  const isFundingGreaterThanBalance = amount.gt(collateralBalance)
-  const error = amount.isZero() || isFundingGreaterThanBalance
+  const isFundingGreaterThanBalance = amountToFund.gt(collateralBalance)
+  const error = amountToFund.isZero() || isFundingGreaterThanBalance
 
   const fundingMessageError = isFundingGreaterThanBalance
     ? `You don't have enough collateral in your balance.`
@@ -200,8 +200,8 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
                   <BigNumberInputTextRight
                     decimals={collateral.decimals}
                     name="amount"
-                    onChange={(e: BigNumberInputReturn) => setAmount(e.value)}
-                    value={amount}
+                    onChange={(e: BigNumberInputReturn) => setAmountToFund(e.value)}
+                    value={amountToFund}
                   />
                 }
                 placeholderText={collateral.symbol}
@@ -215,7 +215,7 @@ const MarketFundWrapper: React.FC<Props> = (props: Props) => {
               <BalanceToken
                 collateral={collateral}
                 collateralBalance={collateralBalance}
-                onClickAddMaxCollateral={() => setAmount(collateralBalance)}
+                onClickAddMaxCollateral={() => setAmountToFund(collateralBalance)}
               />
               <FormError>{fundingMessageError}</FormError>
             </>

--- a/app/src/components/market/market_sell.tsx
+++ b/app/src/components/market/market_sell.tsx
@@ -181,10 +181,10 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
     return (
       <>
         <BalanceShares
-          balanceItem={balanceItem}
+          shares={balanceItem.shares}
           collateral={collateral}
-          onClickMax={(balanceItemSet?: BalanceItem) => {
-            if (balanceItemSet) setAmountShares(balanceItemSet.shares)
+          onClickMax={(shares: BigNumber) => {
+            setAmountShares(shares)
           }}
         />
         <FormError>{sharesMessageError}</FormError>

--- a/app/src/hooks/useFundingBalance.tsx
+++ b/app/src/hooks/useFundingBalance.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+import { ConnectedWeb3Context } from './connectedWeb3'
+import { CPKService } from '../services'
+import { BigNumber } from 'ethers/utils'
+import { useContracts } from './useContracts'
+
+export const useFundingBalance = (
+  marketMakerAddress: string,
+  context: ConnectedWeb3Context,
+): BigNumber => {
+  const { library: provider, account } = context
+  const { buildMarketMaker } = useContracts(context)
+
+  const [fundingBalance, setFundingBalance] = useState<BigNumber>(new BigNumber(0))
+
+  useEffect(() => {
+    const fetchFundingBalance = async () => {
+      let fundingBalance = new BigNumber(0)
+
+      if (account) {
+        const cpk = await CPKService.create(provider)
+        const marketMaker = buildMarketMaker(marketMakerAddress)
+        fundingBalance = await marketMaker.balanceOf(cpk.address)
+      }
+
+      setFundingBalance(fundingBalance)
+    }
+    fetchFundingBalance()
+  }, [account, provider])
+
+  return fundingBalance
+}

--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -40,9 +40,14 @@ interface CPKCreateMarketParams {
   marketMakerFactory: MarketMakerFactoryService
 }
 
-interface CPKFundingParams {
+interface CPKAddFundingParams {
   amount: BigNumber
   collateral: Token
+  marketMaker: MarketMakerService
+}
+
+interface CPKRemoveFundingParams {
+  amount: BigNumber
   marketMaker: MarketMakerService
 }
 
@@ -353,7 +358,7 @@ class CPKService {
     amount,
     collateral,
     marketMaker,
-  }: CPKFundingParams): Promise<TransactionReceipt> => {
+  }: CPKAddFundingParams): Promise<TransactionReceipt> => {
     try {
       const signer = this.provider.getSigner()
       const account = await signer.getAddress()
@@ -408,9 +413,8 @@ class CPKService {
 
   removeFunding = async ({
     amount,
-    collateral,
     marketMaker,
-  }: CPKFundingParams): Promise<TransactionReceipt> => {
+  }: CPKRemoveFundingParams): Promise<TransactionReceipt> => {
     try {
       const transactions = [
         {


### PR DESCRIPTION
Closes #418 

### Includes
- Improve balance shares, allow to pase shares amount as a prop, so we can reuse it
- Create useFundingBalance hook, to know the exact amount of shares the user have
- Add integration in the market fund section, with validations and some checks

#### Does not include
- Maintain the balance of shares with redux
