### PR TITLE
Dynamic values for buy, sell and pool liquidity

### DIFF
--- a/app/src/components/market/market_buy.tsx
+++ b/app/src/components/market/market_buy.tsx
@@ -31,10 +31,10 @@ import { SetAllowance } from '../common/set_allowance'
 import { FullLoading } from '../loading'
 import { ModalTwitterShare } from '../modal/modal_twitter_share'
 
+import { MarketTopDetails } from './market_top_details'
 import { TransactionDetailsCard } from './transaction_details_card'
 import { TransactionDetailsLine } from './transaction_details_line'
 import { TransactionDetailsRow, ValueStates } from './transaction_details_row'
-import { MarketTopDetails } from './market_top_details'
 
 const LeftButton = styled(Button)`
   margin-right: auto;
@@ -179,9 +179,9 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
       <SectionTitle goBackEnabled title={question} />
       <ViewCard>
         <MarketTopDetails
-          toggleTitleAction="Pool Information"
-          title="Purchase Outcome"
           marketMakerAddress={marketMakerAddress}
+          title="Purchase Outcome"
+          toggleTitleAction="Pool Information"
         />
         <OutcomeTable
           balances={balances}

--- a/app/src/components/market/market_buy.tsx
+++ b/app/src/components/market/market_buy.tsx
@@ -13,21 +13,15 @@ import { useCpk } from '../../hooks/useCpk'
 import { useCpkAllowance } from '../../hooks/useCpkAllowance'
 import { MarketMakerService } from '../../services'
 import { getLogger } from '../../util/logger'
-import { computeBalanceAfterTrade, formatBigNumber, formatDate } from '../../util/tools'
+import { computeBalanceAfterTrade, formatBigNumber } from '../../util/tools'
 import { BalanceItem, OutcomeTableValue, Status, Token } from '../../util/types'
 import { Button, ButtonContainer } from '../button'
 import { ButtonType } from '../button/button_styling_types'
 import {
   BigNumberInput,
-  DisplayArbitrator,
   GridTransactionDetails,
-  GridTwoColumns,
   SectionTitle,
-  SubsectionTitle,
-  SubsectionTitleAction,
-  SubsectionTitleWrapper,
   TextfieldCustomPlaceholder,
-  TitleValue,
   ViewCard,
   WalletBalance,
 } from '../common'
@@ -40,7 +34,7 @@ import { ModalTwitterShare } from '../modal/modal_twitter_share'
 import { TransactionDetailsCard } from './transaction_details_card'
 import { TransactionDetailsLine } from './transaction_details_line'
 import { TransactionDetailsRow, ValueStates } from './transaction_details_row'
-import { useMarketMakerData } from '../../hooks'
+import { MarketTopDetails } from './market_top_details'
 
 const LeftButton = styled(Button)`
   margin-right: auto;
@@ -65,16 +59,6 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const { buildMarketMaker } = useContracts(context)
   const { balances, collateral, marketMakerAddress, question } = props
   const marketMaker = useMemo(() => buildMarketMaker(marketMakerAddress), [buildMarketMaker, marketMakerAddress])
-  const { marketMakerData } = useMarketMakerData(marketMakerAddress, context)
-  const {
-    userEarnings,
-    totalEarnings,
-    marketMakerFunding,
-    marketMakerUserFunding,
-    arbitrator,
-    resolution,
-    category,
-  } = marketMakerData
 
   const [status, setStatus] = useState<Status>(Status.Ready)
   const [outcomeIndex, setOutcomeIndex] = useState<number>(0)
@@ -83,10 +67,6 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const [message, setMessage] = useState<string>('')
   const [isModalTwitterShareOpen, setModalTwitterShareState] = useState(false)
   const [messageTwitter, setMessageTwitter] = useState('')
-  const [showingExtraInformation, setExtraInformation] = useState(false)
-
-  const toggleExtraInformation = () =>
-    showingExtraInformation ? setExtraInformation(false) : setExtraInformation(true)
 
   const [allowanceFinished, setAllowanceFinished] = useState(false)
   const { allowance, unlock } = useCpkAllowance(signer, collateral.address)
@@ -198,40 +178,11 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
     <>
       <SectionTitle goBackEnabled title={question} />
       <ViewCard>
-        <SubsectionTitleWrapper>
-          <SubsectionTitle>Purchase Outcome</SubsectionTitle>
-          <SubsectionTitleAction onClick={toggleExtraInformation}>
-            {showingExtraInformation ? 'Hide' : 'Show'} Pool Information
-          </SubsectionTitleAction>
-        </SubsectionTitleWrapper>
-
-        <GridTwoColumns>
-          {showingExtraInformation ? (
-            <>
-              <TitleValue
-                title={'Total Pool Tokens'}
-                value={formatBigNumber(marketMakerFunding, collateral.decimals)}
-              />
-              <TitleValue
-                title={'Total Pool Earings'}
-                value={`${formatBigNumber(userEarnings, collateral.decimals)} ${collateral.symbol}`}
-              />
-              <TitleValue
-                title={'My Pool Tokens'}
-                value={formatBigNumber(marketMakerUserFunding, collateral.decimals)}
-              />
-              <TitleValue
-                title={'My Pool Earnings'}
-                value={`${formatBigNumber(totalEarnings, collateral.decimals)} ${collateral.symbol}`}
-              />
-            </>
-          ) : null}
-          <TitleValue title={'Category'} value={category} />
-          <TitleValue title={'Resolution Date'} value={resolution && formatDate(resolution)} />
-          <TitleValue title={'Arbitrator/Oracle'} value={arbitrator && <DisplayArbitrator arbitrator={arbitrator} />} />
-          <TitleValue title={'24h Volume'} value={'425,523 DAI'} />
-        </GridTwoColumns>
-
+        <MarketTopDetails
+          toggleTitleAction="Pool Information"
+          title="Purchase Outcome"
+          marketMakerAddress={marketMakerAddress}
+        />
         <OutcomeTable
           balances={balances}
           collateral={collateral}

--- a/app/src/components/market/market_pool_liquidity.tsx
+++ b/app/src/components/market/market_pool_liquidity.tsx
@@ -38,6 +38,7 @@ import { FullLoading } from '../loading'
 import { TransactionDetailsCard } from './transaction_details_card'
 import { TransactionDetailsLine } from './transaction_details_line'
 import { TransactionDetailsRow, ValueStates } from './transaction_details_row'
+import { MarketTopDetails } from './market_top_details'
 
 interface Props extends RouteComponentProps<any> {
   marketMakerAddress: string
@@ -197,77 +198,15 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const mockedDeposited = 0.55
   const mockedTokenTotals = 11.55
 
-  const details = (showExtraDetails: boolean) => {
-    const mockedDetails = [
-      {
-        title: 'Total Pool Tokens',
-        value: '5000',
-      },
-      {
-        title: 'Total Pool Earning',
-        value: '25,232 DAI',
-      },
-      {
-        title: 'My Pool Tokens',
-        value: '0',
-      },
-      {
-        title: 'My Earnings',
-        value: '0 DAI',
-      },
-
-      {
-        title: 'Category',
-        value: 'Politics',
-      },
-      {
-        title: 'Resolution Date',
-        value: '25.09.19 - 09:00',
-      },
-      {
-        title: 'Arbitrator/Oracle',
-        value: (
-          <DisplayArbitrator
-            arbitrator={{ id: 'realitio', address: '0x1234567890', name: 'Realit.io', url: 'https://realit.io/' }}
-          />
-        ),
-      },
-      {
-        title: '24h Volume',
-        value: '425,523 DAI',
-      },
-    ]
-    const mockedDetailsLastHalf = mockedDetails.splice(4, 8)
-
-    return (
-      <>
-        <GridTwoColumns>
-          {showExtraDetails ? (
-            <>
-              {mockedDetails.map((item, index) => (
-                <TitleValue key={index} title={item.title} value={item.value} />
-              ))}
-            </>
-          ) : null}
-          {mockedDetailsLastHalf.map((item, index) => (
-            <TitleValue key={index} title={item.title} value={item.value} />
-          ))}
-        </GridTwoColumns>
-      </>
-    )
-  }
-
   return (
     <>
       <SectionTitle goBackEnabled title={question} />
       <ViewCard>
-        <SubsectionTitleWrapper>
-          <SubsectionTitle>Pool Liquidity</SubsectionTitle>
-          <SubsectionTitleAction onClick={toggleExtraInformation}>
-            {showingExtraInformation ? 'Hide' : 'Show'} Market Information
-          </SubsectionTitleAction>
-        </SubsectionTitleWrapper>
-        {details(showingExtraInformation)}
+        <MarketTopDetails
+          title="Pool Liquidity"
+          toggleTitleAction="Market Information"
+          marketMakerAddress={marketMakerAddress}
+        />
         <OutcomeTable
           balances={balances}
           collateral={collateral}

--- a/app/src/components/market/market_pool_liquidity.tsx
+++ b/app/src/components/market/market_pool_liquidity.tsx
@@ -18,15 +18,9 @@ import { Button, ButtonContainer, ButtonTab } from '../button'
 import { ButtonType } from '../button/button_styling_types'
 import {
   BigNumberInput,
-  DisplayArbitrator,
   GridTransactionDetails,
-  GridTwoColumns,
   SectionTitle,
-  SubsectionTitle,
-  SubsectionTitleAction,
-  SubsectionTitleWrapper,
   TextfieldCustomPlaceholder,
-  TitleValue,
   ViewCard,
   WalletBalance,
 } from '../common'
@@ -35,10 +29,10 @@ import { OutcomeTable } from '../common/outcome_table'
 import { SetAllowance } from '../common/set_allowance'
 import { FullLoading } from '../loading'
 
+import { MarketTopDetails } from './market_top_details'
 import { TransactionDetailsCard } from './transaction_details_card'
 import { TransactionDetailsLine } from './transaction_details_line'
 import { TransactionDetailsRow, ValueStates } from './transaction_details_row'
-import { MarketTopDetails } from './market_top_details'
 
 interface Props extends RouteComponentProps<any> {
   marketMakerAddress: string
@@ -98,10 +92,6 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const [amountToRemove, setAmountToRemove] = useState<BigNumber>(new BigNumber(0))
   const [status, setStatus] = useState<Status>(Status.Ready)
   const [message, setMessage] = useState<string>('')
-  const [showingExtraInformation, setExtraInformation] = useState(false)
-
-  const toggleExtraInformation = () =>
-    showingExtraInformation ? setExtraInformation(false) : setExtraInformation(true)
 
   const [activeTab, setActiveTab] = useState(Tabs.deposit)
 
@@ -203,9 +193,9 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
       <SectionTitle goBackEnabled title={question} />
       <ViewCard>
         <MarketTopDetails
+          marketMakerAddress={marketMakerAddress}
           title="Pool Liquidity"
           toggleTitleAction="Market Information"
-          marketMakerAddress={marketMakerAddress}
         />
         <OutcomeTable
           balances={balances}

--- a/app/src/components/market/market_sell.tsx
+++ b/app/src/components/market/market_sell.tsx
@@ -33,6 +33,7 @@ import { FullLoading } from '../loading'
 import { TransactionDetailsCard } from './transaction_details_card'
 import { TransactionDetailsLine } from './transaction_details_line'
 import { TransactionDetailsRow, ValueStates } from './transaction_details_row'
+import { MarketTopDetails } from './market_top_details'
 
 const LeftButton = styled(Button)`
   margin-right: auto;
@@ -146,66 +147,6 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
 
   const error = (status !== Status.Ready && status !== Status.Error) || amountShares.isZero() || !haveEnoughShares
 
-  const details = (showExtraDetails: boolean) => {
-    const mockedDetails = [
-      {
-        title: 'Total Pool Tokens',
-        value: '5000',
-      },
-      {
-        title: 'Total Pool Earning',
-        value: '25,232 DAI',
-      },
-      {
-        title: 'My Pool Tokens',
-        value: '0',
-      },
-      {
-        title: 'My Earnings',
-        value: '0 DAI',
-      },
-
-      {
-        title: 'Category',
-        value: 'Politics',
-      },
-      {
-        title: 'Resolution Date',
-        value: '25.09.19 - 09:00',
-      },
-      {
-        title: 'Arbitrator/Oracle',
-        value: (
-          <DisplayArbitrator
-            arbitrator={{ id: 'realitio', address: '0x1234567890', name: 'Realit.io', url: 'https://realit.io/' }}
-          />
-        ),
-      },
-      {
-        title: '24h Volume',
-        value: '425,523 DAI',
-      },
-    ]
-    const mockedDetailsLastHalf = mockedDetails.splice(4, 8)
-
-    return (
-      <>
-        <GridTwoColumns>
-          {showExtraDetails ? (
-            <>
-              {mockedDetails.map((item, index) => (
-                <TitleValue key={index} title={item.title} value={item.value} />
-              ))}
-            </>
-          ) : null}
-          {mockedDetailsLastHalf.map((item, index) => (
-            <TitleValue key={index} title={item.title} value={item.value} />
-          ))}
-        </GridTwoColumns>
-      </>
-    )
-  }
-
   const noteAmount = `${formatBigNumber(balanceItem.shares, collateral.decimals)} shares`
 
   const mockedPotential = '1.03'
@@ -215,13 +156,11 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
     <>
       <SectionTitle goBackEnabled title={question} />
       <ViewCard>
-        <SubsectionTitleWrapper>
-          <SubsectionTitle>Choose the shares you want to sell</SubsectionTitle>
-          <SubsectionTitleAction onClick={toggleExtraInformation}>
-            {showingExtraInformation ? 'Hide' : 'Show'} Pool Information
-          </SubsectionTitleAction>
-        </SubsectionTitleWrapper>
-        {details(showingExtraInformation)}
+        <MarketTopDetails
+          title="Choose the shares you want to sell"
+          toggleTitleAction="Pool Information"
+          marketMakerAddress={marketMakerAddress}
+        />
         <OutcomeTable
           balances={balances}
           collateral={collateral}

--- a/app/src/components/market/market_sell.tsx
+++ b/app/src/components/market/market_sell.tsx
@@ -14,15 +14,9 @@ import { Button, ButtonContainer } from '../button'
 import { ButtonType } from '../button/button_styling_types'
 import {
   BigNumberInput,
-  DisplayArbitrator,
   GridTransactionDetails,
-  GridTwoColumns,
   SectionTitle,
-  SubsectionTitle,
-  SubsectionTitleAction,
-  SubsectionTitleWrapper,
   TextfieldCustomPlaceholder,
-  TitleValue,
   ViewCard,
   WalletBalance,
 } from '../common'
@@ -30,10 +24,10 @@ import { BigNumberInputReturn } from '../common/big_number_input'
 import { OutcomeTable } from '../common/outcome_table'
 import { FullLoading } from '../loading'
 
+import { MarketTopDetails } from './market_top_details'
 import { TransactionDetailsCard } from './transaction_details_card'
 import { TransactionDetailsLine } from './transaction_details_line'
 import { TransactionDetailsRow, ValueStates } from './transaction_details_row'
-import { MarketTopDetails } from './market_top_details'
 
 const LeftButton = styled(Button)`
   margin-right: auto;
@@ -62,10 +56,6 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
   const [balanceItem, setBalanceItem] = useState<BalanceItem>(balances[outcomeIndex])
   const [amountShares, setAmountShares] = useState<BigNumber>(new BigNumber(0))
   const [message, setMessage] = useState<string>('')
-  const [showingExtraInformation, setExtraInformation] = useState(false)
-
-  const toggleExtraInformation = () =>
-    showingExtraInformation ? setExtraInformation(false) : setExtraInformation(true)
 
   const marketFeeWithTwoDecimals = MARKET_FEE / Math.pow(10, 2)
 
@@ -157,9 +147,9 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
       <SectionTitle goBackEnabled title={question} />
       <ViewCard>
         <MarketTopDetails
+          marketMakerAddress={marketMakerAddress}
           title="Choose the shares you want to sell"
           toggleTitleAction="Pool Information"
-          marketMakerAddress={marketMakerAddress}
         />
         <OutcomeTable
           balances={balances}

--- a/app/src/components/market/market_top_details.tsx
+++ b/app/src/components/market/market_top_details.tsx
@@ -119,7 +119,7 @@ const MarketTopDetails: React.FC<Props> = (props: Props) => {
             />
             <TitleValue
               title={'Total Pool Earings'}
-              value={collateral && `${formatBigNumber(userEarnings, collateral.decimals)} ${collateral.symbol}`}
+              value={collateral && `${formatBigNumber(totalEarnings, collateral.decimals)} ${collateral.symbol}`}
             />
             <TitleValue
               title={'My Pool Tokens'}
@@ -127,7 +127,7 @@ const MarketTopDetails: React.FC<Props> = (props: Props) => {
             />
             <TitleValue
               title={'My Pool Earnings'}
-              value={collateral && `${formatBigNumber(totalEarnings, collateral.decimals)} ${collateral.symbol}`}
+              value={collateral && `${formatBigNumber(userEarnings, collateral.decimals)} ${collateral.symbol}`}
             />
           </>
         ) : null}

--- a/app/src/components/market/market_top_details.tsx
+++ b/app/src/components/market/market_top_details.tsx
@@ -118,7 +118,7 @@ const MarketTopDetails: React.FC<Props> = (props: Props) => {
               value={collateral && formatBigNumber(marketMakerFunding, collateral.decimals)}
             />
             <TitleValue
-              title={'Total Pool Earings'}
+              title={'Total Pool Earnings'}
               value={collateral && `${formatBigNumber(totalEarnings, collateral.decimals)} ${collateral.symbol}`}
             />
             <TitleValue

--- a/app/src/components/market/market_top_details.tsx
+++ b/app/src/components/market/market_top_details.tsx
@@ -1,0 +1,150 @@
+import { useQuery } from '@apollo/react-hooks'
+import { BigNumber } from 'ethers/utils'
+import gql from 'graphql-tag'
+import React, { useEffect, useState } from 'react'
+
+import { useMarketMakerData } from '../../hooks'
+import { useConnectedWeb3Context } from '../../hooks/connectedWeb3'
+import { getLogger } from '../../util/logger'
+import {
+  DisplayArbitrator,
+  GridTwoColumns,
+  SubsectionTitle,
+  SubsectionTitleAction,
+  SubsectionTitleWrapper,
+  TitleValue,
+} from '../common'
+import { formatBigNumber, formatDate } from '../../util/tools'
+const logger = getLogger('Market::View')
+
+interface Props {
+  toggleTitleAction: string
+  title: string
+  marketMakerAddress: string
+}
+
+const GET_COLLATERAL_VOLUME_NOW = gql`
+  query Current($id: String) {
+    fixedProductMarketMakers(where: { id: $id }) {
+      collateralVolume
+    }
+  }
+`
+
+const buildQuery24hsEarlier = (hash: Maybe<string>) => {
+  return gql`
+  query AfterHash($id: String) {
+    fixedProductMarketMakers(where: { id: $id }, block: { hash: "${hash}" }) {
+      collateralVolume
+    }
+  }
+`
+}
+
+const MarketTopDetails: React.FC<Props> = (props: Props) => {
+  const context = useConnectedWeb3Context()
+  const [showingExtraInformation, setExtraInformation] = useState(false)
+
+  const toggleExtraInformation = () =>
+    showingExtraInformation ? setExtraInformation(false) : setExtraInformation(true)
+
+  const { marketMakerAddress } = props
+
+  const [hash, setHash] = useState<Maybe<string>>(null)
+  const { marketMakerData } = useMarketMakerData(marketMakerAddress, context)
+  const { library: provider } = context
+
+  const [lastDayVolume, setLastDayVolume] = useState<Maybe<BigNumber>>(null)
+
+  const { data: volumeNow, error: errorVolumeNow } = useQuery(GET_COLLATERAL_VOLUME_NOW, {
+    skip: !!lastDayVolume,
+    variables: { id: marketMakerAddress.toLowerCase() },
+  })
+
+  const { data: volumeBefore, error: errorVolumeBefore } = useQuery(buildQuery24hsEarlier(hash && hash.toLowerCase()), {
+    skip: !!lastDayVolume || !hash,
+    variables: { id: marketMakerAddress.toLowerCase() },
+  })
+
+  if (errorVolumeBefore || errorVolumeNow) {
+    setLastDayVolume(null)
+    errorVolumeBefore && logger.log(errorVolumeBefore)
+    errorVolumeNow && logger.log(errorVolumeNow)
+  } else if (volumeNow && volumeBefore) {
+    const marketNow = volumeNow.fixedProductMarketMakers[0]
+    const marketBefore = volumeBefore.fixedProductMarketMakers[0]
+    const now = new BigNumber(marketNow ? marketNow.collateralVolume : 0)
+    const before = new BigNumber(marketBefore ? marketBefore.collateralVolume : 0)
+
+    setLastDayVolume(now.sub(before))
+  }
+  const {
+    userEarnings,
+    totalEarnings,
+    marketMakerUserFunding,
+    arbitrator,
+    category,
+    collateral,
+    marketMakerFunding,
+    resolution,
+  } = marketMakerData
+
+  useEffect(() => {
+    const get24hsVolume = async () => {
+      const BLOCKS_PER_SECOND = 15
+      const OFFSET = Math.round((60 * 60 * 24) / BLOCKS_PER_SECOND)
+      const lastBlock = await provider.getBlockNumber()
+      const { hash } = await provider.getBlock(lastBlock - OFFSET)
+      setHash(hash)
+    }
+
+    get24hsVolume()
+  }, [provider])
+
+  return (
+    <>
+      <SubsectionTitleWrapper>
+        <SubsectionTitle>{props.title}</SubsectionTitle>
+        <SubsectionTitleAction onClick={toggleExtraInformation}>
+          {showingExtraInformation ? 'Hide' : 'Show'} {props.toggleTitleAction}
+        </SubsectionTitleAction>
+      </SubsectionTitleWrapper>
+
+      <GridTwoColumns>
+        {showingExtraInformation ? (
+          <>
+            <TitleValue
+              title={'Total Pool Tokens'}
+              value={collateral && formatBigNumber(marketMakerFunding, collateral.decimals)}
+            />
+            <TitleValue
+              title={'Total Pool Earings'}
+              value={collateral && `${formatBigNumber(userEarnings, collateral.decimals)} ${collateral.symbol}`}
+            />
+            <TitleValue
+              title={'My Pool Tokens'}
+              value={collateral && formatBigNumber(marketMakerUserFunding, collateral.decimals)}
+            />
+            <TitleValue
+              title={'My Pool Earnings'}
+              value={collateral && `${formatBigNumber(totalEarnings, collateral.decimals)} ${collateral.symbol}`}
+            />
+          </>
+        ) : null}
+        <TitleValue title={'Category'} value={category} />
+        <TitleValue title={'Resolution Date'} value={resolution && formatDate(resolution)} />
+        <TitleValue title={'Arbitrator/Oracle'} value={arbitrator && <DisplayArbitrator arbitrator={arbitrator} />} />
+        <TitleValue
+          title={'24h Volume'}
+          value={
+            collateral && lastDayVolume
+              ? `${formatBigNumber(lastDayVolume, collateral.decimals)} ${collateral.symbol}`
+              : '-'
+          }
+        />
+      </GridTwoColumns>
+    </>
+  )
+}
+
+export { MarketTopDetails }

--- a/app/src/components/market/market_top_details.tsx
+++ b/app/src/components/market/market_top_details.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react'
 import { useMarketMakerData } from '../../hooks'
 import { useConnectedWeb3Context } from '../../hooks/connectedWeb3'
 import { getLogger } from '../../util/logger'
+import { formatBigNumber, formatDate } from '../../util/tools'
 import {
   DisplayArbitrator,
   GridTwoColumns,
@@ -14,7 +15,6 @@ import {
   SubsectionTitleWrapper,
   TitleValue,
 } from '../common'
-import { formatBigNumber, formatDate } from '../../util/tools'
 const logger = getLogger('Market::View')
 
 interface Props {
@@ -79,14 +79,14 @@ const MarketTopDetails: React.FC<Props> = (props: Props) => {
     setLastDayVolume(now.sub(before))
   }
   const {
-    userEarnings,
-    totalEarnings,
-    marketMakerUserFunding,
     arbitrator,
     category,
     collateral,
     marketMakerFunding,
+    marketMakerUserFunding,
     resolution,
+    totalEarnings,
+    userEarnings,
   } = marketMakerData
 
   useEffect(() => {

--- a/app/src/components/market/market_view.tsx
+++ b/app/src/components/market/market_view.tsx
@@ -21,7 +21,6 @@ interface Props {
   questionId: string
   resolution: Maybe<Date>
   status: Status
-  lastDayVolume: Maybe<BigNumber>
   totalPoolShares: BigNumber
   userPoolShares: BigNumber
 }

--- a/app/src/components/market/market_view_container.tsx
+++ b/app/src/components/market/market_view_container.tsx
@@ -1,37 +1,13 @@
-import { useQuery } from '@apollo/react-hooks'
-import { BigNumber } from 'ethers/utils'
-import gql from 'graphql-tag'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useMarketMakerData } from '../../hooks'
 import { useConnectedWeb3Context } from '../../hooks/connectedWeb3'
-import { getLogger } from '../../util/logger'
 import { FullLoading } from '../loading'
 
 import { MarketView } from './market_view'
 
-const logger = getLogger('Market::View')
-
 interface Props {
   marketMakerAddress: string
-}
-
-const GET_COLLATERAL_VOLUME_NOW = gql`
-  query Current($id: String) {
-    fixedProductMarketMakers(where: { id: $id }) {
-      collateralVolume
-    }
-  }
-`
-
-const buildQuery24hsEarlier = (hash: Maybe<string>) => {
-  return gql`
-  query AfterHash($id: String) {
-    fixedProductMarketMakers(where: { id: $id }, block: { hash: "${hash}" }) {
-      collateralVolume
-    }
-  }
-`
 }
 
 const MarketViewContainer: React.FC<Props> = (props: Props) => {
@@ -39,34 +15,7 @@ const MarketViewContainer: React.FC<Props> = (props: Props) => {
 
   const { marketMakerAddress } = props
 
-  const [hash, setHash] = useState<Maybe<string>>(null)
   const { marketMakerData, status } = useMarketMakerData(marketMakerAddress, context)
-  const { library: provider } = context
-
-  const [lastDayVolume, setLastDayVolume] = useState<Maybe<BigNumber>>(null)
-
-  const { data: volumeNow, error: errorVolumeNow } = useQuery(GET_COLLATERAL_VOLUME_NOW, {
-    skip: !!lastDayVolume,
-    variables: { id: marketMakerAddress.toLowerCase() },
-  })
-
-  const { data: volumeBefore, error: errorVolumeBefore } = useQuery(buildQuery24hsEarlier(hash && hash.toLowerCase()), {
-    skip: !!lastDayVolume || !hash,
-    variables: { id: marketMakerAddress.toLowerCase() },
-  })
-
-  if (errorVolumeBefore || errorVolumeNow) {
-    setLastDayVolume(null)
-    errorVolumeBefore && logger.log(errorVolumeBefore)
-    errorVolumeNow && logger.log(errorVolumeNow)
-  } else if (volumeNow && volumeBefore) {
-    const marketNow = volumeNow.fixedProductMarketMakers[0]
-    const marketBefore = volumeBefore.fixedProductMarketMakers[0]
-    const now = new BigNumber(marketNow ? marketNow.collateralVolume : 0)
-    const before = new BigNumber(marketBefore ? marketBefore.collateralVolume : 0)
-
-    setLastDayVolume(now.sub(before))
-  }
 
   const {
     arbitrator,
@@ -83,18 +32,6 @@ const MarketViewContainer: React.FC<Props> = (props: Props) => {
     userPoolShares,
   } = marketMakerData
 
-  useEffect(() => {
-    const get24hsVolume = async () => {
-      const BLOCKS_PER_SECOND = 15
-      const OFFSET = Math.round((60 * 60 * 24) / BLOCKS_PER_SECOND)
-      const lastBlock = await provider.getBlockNumber()
-      const { hash } = await provider.getBlock(lastBlock - OFFSET)
-      setHash(hash)
-    }
-
-    get24hsVolume()
-  }, [provider])
-
   if (!collateral) {
     return <FullLoading />
   }
@@ -109,7 +46,6 @@ const MarketViewContainer: React.FC<Props> = (props: Props) => {
       funding={marketMakerFunding}
       isConditionResolved={isConditionResolved}
       isQuestionFinalized={isQuestionFinalized}
-      lastDayVolume={lastDayVolume}
       marketMakerAddress={marketMakerAddress}
       question={question || ''}
       questionId={questionId}

--- a/app/src/components/market/profile/view.tsx
+++ b/app/src/components/market/profile/view.tsx
@@ -1,10 +1,9 @@
 import { BigNumber } from 'ethers/utils'
-import React, { useState } from 'react'
+import React from 'react'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { WhenConnected } from '../../../hooks/connectedWeb3'
-import { formatBigNumber } from '../../../util/tools'
 import { Arbitrator, BalanceItem, OutcomeTableValue, Status, Token } from '../../../util/types'
 import { Button, ButtonContainer } from '../../button'
 import { ButtonType } from '../../button/button_styling_types'
@@ -62,9 +61,9 @@ const ViewWrapper = (props: Props) => {
     <>
       <ViewCard>
         <MarketTopDetails
+          marketMakerAddress={marketMakerAddress}
           title="Purchase Outcome"
           toggleTitleAction="Pool Information"
-          marketMakerAddress={marketMakerAddress}
         />
         {renderTableData()}
         <WhenConnected>

--- a/app/src/components/market/profile/view.tsx
+++ b/app/src/components/market/profile/view.tsx
@@ -8,18 +8,10 @@ import { formatBigNumber } from '../../../util/tools'
 import { Arbitrator, BalanceItem, OutcomeTableValue, Status, Token } from '../../../util/types'
 import { Button, ButtonContainer } from '../../button'
 import { ButtonType } from '../../button/button_styling_types'
-import {
-  DisplayArbitrator,
-  GridTwoColumns,
-  SubsectionTitle,
-  SubsectionTitleAction,
-  SubsectionTitleWrapper,
-  ThreeBoxComments,
-  TitleValue,
-  ViewCard,
-} from '../../common'
+import { ThreeBoxComments, ViewCard } from '../../common'
 import { OutcomeTable } from '../../common/outcome_table'
 import { FullLoading } from '../../loading'
+import { MarketTopDetails } from '../market_top_details'
 
 const LeftButton = styled(Button)`
   margin-right: auto;
@@ -36,29 +28,12 @@ interface Props extends RouteComponentProps<{}> {
   status: Status
   marketMakerAddress: string
   funding: BigNumber
-  lastDayVolume: Maybe<BigNumber>
   totalPoolShares: BigNumber
   userPoolShares: BigNumber
 }
 
 const ViewWrapper = (props: Props) => {
-  const {
-    arbitrator,
-    balances,
-    category,
-    collateral,
-    history,
-    lastDayVolume,
-    marketMakerAddress,
-    questionId,
-    status,
-    totalPoolShares,
-    userPoolShares,
-  } = props
-  const [showingExtraInformation, setExtraInformation] = useState(false)
-
-  const toggleExtraInformation = () =>
-    showingExtraInformation ? setExtraInformation(false) : setExtraInformation(true)
+  const { balances, collateral, history, marketMakerAddress, status } = props
 
   const userHasShares = balances.some((balanceItem: BalanceItem) => {
     const { shares } = balanceItem
@@ -83,61 +58,14 @@ const ViewWrapper = (props: Props) => {
     )
   }
 
-  const details = (showExtraDetails: boolean) => {
-    return (
-      <>
-        <GridTwoColumns>
-          {category && <TitleValue title={'Category'} value={category} />}
-          <TitleValue title={'Arbitrator'} value={arbitrator && <DisplayArbitrator arbitrator={arbitrator} />} />
-          {questionId && (
-            <TitleValue
-              title={'Realitio'}
-              value={
-                <a
-                  href={`https://realitio.github.io/#!/question/${questionId}`}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Question URL
-                </a>
-              }
-            />
-          )}
-          <TitleValue
-            title="24h Volume"
-            value={lastDayVolume ? `${formatBigNumber(lastDayVolume, collateral.decimals)} ${collateral.symbol}` : '-'}
-          />
-          {showExtraDetails ? (
-            <>
-              <TitleValue
-                title={'Total Pool Tokens'}
-                value={totalPoolShares ? formatBigNumber(totalPoolShares, collateral.decimals) : '0'}
-              />
-              <TitleValue
-                title={'My Pool Tokens'}
-                value={userPoolShares ? formatBigNumber(userPoolShares, collateral.decimals) : '0'}
-              />
-              <TitleValue title={'Total Pool Earnings'} value={'Mocked Value 3'} />
-              <TitleValue title={'My Earnings'} value={'Mocked Value 4'} />
-            </>
-          ) : null}
-        </GridTwoColumns>
-      </>
-    )
-  }
-
-  const marketHasDetails = category || arbitrator
-
   return (
     <>
       <ViewCard>
-        <SubsectionTitleWrapper>
-          <SubsectionTitle>Market Information</SubsectionTitle>
-          <SubsectionTitleAction onClick={toggleExtraInformation}>
-            {showingExtraInformation ? 'Hide' : 'Show'} Pool Information
-          </SubsectionTitleAction>
-        </SubsectionTitleWrapper>
-        {marketHasDetails && details(showingExtraInformation)}
+        <MarketTopDetails
+          title="Purchase Outcome"
+          toggleTitleAction="Pool Information"
+          marketMakerAddress={marketMakerAddress}
+        />
         {renderTableData()}
         <WhenConnected>
           <ButtonContainer>

--- a/app/src/hooks/useMarketMakerData.tsx
+++ b/app/src/hooks/useMarketMakerData.tsx
@@ -28,6 +28,8 @@ interface MarketMakerData {
   isConditionResolved: boolean
   fee: Maybe<BigNumber>
   isQuestionFinalized: boolean
+  userEarnings: BigNumber
+  totalEarnings: BigNumber
 }
 
 export const useMarketMakerData = (
@@ -56,6 +58,8 @@ export const useMarketMakerData = (
       isQuestionFinalized: false,
       isConditionResolved: false,
       fee: null,
+      userEarnings: new BigNumber(0),
+      totalEarnings: new BigNumber(0),
     }),
     [],
   )
@@ -88,6 +92,7 @@ export const useMarketMakerData = (
       userPoolShares,
       fee,
       isQuestionFinalized,
+      userEarnings,
     ] = await Promise.all([
       cpk && cpk.address
         ? marketMaker.getBalanceInformation(cpk.address, outcomes.length)
@@ -100,7 +105,10 @@ export const useMarketMakerData = (
       cpk && cpk.address ? marketMaker.poolSharesBalanceOf(cpk.address) : new BigNumber(0),
       marketMaker.getFee(),
       realitio.isFinalized(questionId),
+      cpk && cpk.address ? marketMaker.getFeesWithdrawableBy(cpk.address) : new BigNumber(0),
     ])
+
+    const totalEarnings = await marketMaker.getCollectedFees()
 
     const winnerOutcome = isQuestionFinalized ? await realitio.getWinnerOutcome(questionId) : null
 
@@ -144,6 +152,8 @@ export const useMarketMakerData = (
       isQuestionFinalized,
       isConditionResolved,
       fee,
+      userEarnings,
+      totalEarnings,
     }
   }, [conditionalTokens, provider, networkId, account, marketMakerAddress, realitio, buildMarketMaker])
 

--- a/app/src/services/market_maker.ts
+++ b/app/src/services/market_maker.ts
@@ -19,6 +19,8 @@ const marketMakerAbi = [
   'function addFunding(uint addedFunds, uint[] distributionHint) external',
   'function removeFunding(uint sharesToBurn) external',
   'function totalSupply() external view returns (uint256)',
+  'function collectedFees() external view returns (uint)',
+  'function feesWithdrawableBy(address addr) public view returns (uint)',
   'function buy(uint investmentAmount, uint outcomeIndex, uint minOutcomeTokensToBuy) external',
   'function calcBuyAmount(uint investmentAmount, uint outcomeIndex) public view returns (uint)',
   'function sell(uint returnAmount, uint outcomeIndex, uint maxOutcomeTokensToSell) external',
@@ -73,6 +75,14 @@ class MarketMakerService {
 
   getTotalSupply = async (): Promise<BigNumber> => {
     return this.contract.totalSupply()
+  }
+
+  getCollectedFees = async (): Promise<BigNumber> => {
+    return this.contract.collectedFees()
+  }
+
+  getFeesWithdrawableBy = async (account: string): Promise<BigNumber> => {
+    return this.contract.feesWithdrawableBy(account)
   }
 
   addInitialFunding = async (amount: BigNumber, initialOdds: number[]) => {


### PR DESCRIPTION
 There are still some hardcoded values related to potential profit in buy and sell pages, values in `TransactionDetailsCard`, and OwnedShares, those are pending to ask how are calculated or if it make sense to have them.

I made a component for the market's details repeated across buy/sell/liquidity/detail

Part of #467. From that list, it does:

- Total Pool Tokens (buy, sell, detail...)
- My Pool Tokens
- Total Pool Earnings
- My Pool Earnings
- 24hs volume (buy, sell, ...) 