### PR TITLE
(fix) List items underlined text

### DIFF
--- a/app/src/components/common/list_item/index.tsx
+++ b/app/src/components/common/list_item/index.tsx
@@ -15,6 +15,7 @@ const Wrapper = styled(NavLink)`
   flex-direction: column;
   justify-content: center;
   padding: 22px 25px;
+  text-decoration: none;
 
   &:active,
   &:hover {


### PR DESCRIPTION
No related issue.

Items' text was looking like this:

![Screen Shot 2020-04-06 at 15 00 12](https://user-images.githubusercontent.com/4015436/78590195-d74dc300-7817-11ea-8dcf-5dd084d91389.png)

It should look like this now:

![Screen Shot 2020-04-06 at 15 01 23](https://user-images.githubusercontent.com/4015436/78590226-e0d72b00-7817-11ea-842a-eba6d83d0f8d.png)
