### PR TITLE
Change conditions for resolve and redeem buttons

### DIFF
--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -128,10 +128,10 @@ export const OutcomeTable = (props: Props) => {
 
   const RedeemAmount = (props: any) => {
     const { balance, index } = props
-
-    if (!payouts) return null
-
     const shares = new Big(balance.shares.toString())
+
+    if (!payouts || shares.eq(0)) return null
+
     const redeemable = new BigNumber(shares.mul(payouts[index]).toString())
 
     return (
@@ -210,7 +210,7 @@ export const OutcomeTable = (props: Props) => {
         {disabledColumns.includes(OutcomeTableValue.Outcome) ? null : (
           <TDStyled textAlign={TableCellsAlign[4]}>
             <OutcomeItemTextWrapper>
-              {!isWinningOutcome && <OutcomeItemLittleBallOfJoyAndDifferentColors outcomeIndex={outcomeIndex} />}
+              {<OutcomeItemLittleBallOfJoyAndDifferentColors outcomeIndex={outcomeIndex} />}
               <OutcomeItemText>{outcomeName}</OutcomeItemText>
               {isWinningOutcome && <WinningOutcome balance={balanceItem} index={outcomeIndex} />}
             </OutcomeItemTextWrapper>

--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -174,23 +174,22 @@ export const ClosedMarketDetail = (props: Props) => {
               winnersOutcomes={winnersOutcomes}
             ></MarketResolutionMessageStyled>
           )}
-          {isConditionResolved ||
-            (hasWinningOutcomes && (
-              <>
-                <ButtonContainerFullWidth borderTop={true}>
-                  {!isConditionResolved && (
-                    <Button buttonType={ButtonType.primary} onClick={resolveCondition}>
-                      Resolve Condition
-                    </Button>
-                  )}
-                  {isConditionResolved && hasWinningOutcomes && (
-                    <Button buttonType={ButtonType.primary} onClick={() => redeem()}>
-                      Redeem
-                    </Button>
-                  )}
-                </ButtonContainerFullWidth>
-              </>
-            ))}
+          {isConditionResolved && !hasWinningOutcomes ? null : (
+            <>
+              <ButtonContainerFullWidth borderTop={true}>
+                {!isConditionResolved && (
+                  <Button buttonType={ButtonType.primary} onClick={resolveCondition}>
+                    Resolve Condition
+                  </Button>
+                )}
+                {isConditionResolved && hasWinningOutcomes && (
+                  <Button buttonType={ButtonType.primary} onClick={() => redeem()}>
+                    Redeem
+                  </Button>
+                )}
+              </ButtonContainerFullWidth>
+            </>
+          )}
         </WhenConnected>
       </ViewCard>
       {status === Status.Loading && <FullLoading message={message} />}

--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -178,7 +178,7 @@ export const ClosedMarketDetail = (props: Props) => {
             (hasWinningOutcomes && (
               <>
                 <ButtonContainerFullWidth borderTop={true}>
-                  {!isConditionResolved && hasWinningOutcomes && (
+                  {!isConditionResolved && (
                     <Button buttonType={ButtonType.primary} onClick={resolveCondition}>
                       Resolve Condition
                     </Button>

--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -178,12 +178,16 @@ export const ClosedMarketDetail = (props: Props) => {
             <>
               <ButtonContainerFullWidth borderTop={true}>
                 {!isConditionResolved && (
-                  <Button buttonType={ButtonType.primary} onClick={resolveCondition}>
+                  <Button
+                    buttonType={ButtonType.primary}
+                    disabled={status === Status.Loading}
+                    onClick={resolveCondition}
+                  >
                     Resolve Condition
                   </Button>
                 )}
                 {isConditionResolved && hasWinningOutcomes && (
-                  <Button buttonType={ButtonType.primary} onClick={() => redeem()}>
+                  <Button buttonType={ButtonType.primary} disabled={status === Status.Loading} onClick={() => redeem()}>
                     Redeem
                   </Button>
                 )}


### PR DESCRIPTION
The logic is:

- If the condition is not resolved, the "Resolve" button is shown _even if the user doesn't have winning outcomes_. This is for letting anyone (for example the market creator) resolve the condition.
- If the condition is resolved *and* the user has winning outcomes, the redeem button is shown.
- If the condition is resolved and the user doesn't have winning outcomes, nothing is shown (not even the container; not sure if this was necessary UI-wise but just in case).