### PR TITLE
Feature/ show shares column when buy or sell shares screen is shown

### DIFF
--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -130,7 +130,7 @@ export const OutcomeTable = (props: Props) => {
     const { balance, index } = props
     const shares = new Big(balance.shares.toString())
 
-    if (!payouts || shares.eq(0)) return null
+    if (!payouts || !shares.eq(0)) return null
 
     const redeemable = new BigNumber(shares.mul(payouts[index]).toString())
 
@@ -181,6 +181,7 @@ export const OutcomeTable = (props: Props) => {
     const showSharesAndPriceChange = isOutcomeSelected && !IS_CORONA_VERSION
     const formattedPayout = formatBigNumber(mulBN(shares, payout), collateral.decimals)
     const isWinningOutcome = payouts && payouts[outcomeIndex] > 0
+    const formattedShares = formatBigNumber(shares, collateral.decimals)
 
     return (
       <TR key={outcomeName}>
@@ -199,12 +200,12 @@ export const OutcomeTable = (props: Props) => {
         {disabledColumns.includes(OutcomeTableValue.OutcomeProbability) ? null : withWinningOutcome ? (
           <TDStyled textAlign={TableCellsAlign[1]}>
             <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
-            {showSharesAndPriceChange && <OwnedShares outcomeIndex={outcomeIndex} value="250.55" />}
+            {!shares.isZero() && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
           </TDStyled>
         ) : (
           <TDStyled textAlign={TableCellsAlign[1]}>
             <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
-            {showSharesAndPriceChange && <OwnedShares outcomeIndex={outcomeIndex} value="250.55" />}
+            {!shares.isZero() && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
           </TDStyled>
         )}
         {disabledColumns.includes(OutcomeTableValue.Outcome) ? null : (
@@ -236,9 +237,9 @@ export const OutcomeTable = (props: Props) => {
           </TDStyled>
         )}
         {disabledColumns.includes(OutcomeTableValue.Shares) ? null : withWinningOutcome ? (
-          <TDStyled textAlign={TableCellsAlign[3]}>{formatBigNumber(shares, collateral.decimals)}</TDStyled>
+          <TDStyled textAlign={TableCellsAlign[3]}>{formattedShares}</TDStyled>
         ) : (
-          <TDStyled textAlign={TableCellsAlign[3]}>{formatBigNumber(shares, collateral.decimals)}</TDStyled>
+          <TDStyled textAlign={TableCellsAlign[3]}>{formattedShares}</TDStyled>
         )}
         {disabledColumns.includes(OutcomeTableValue.Payout) ? null : withWinningOutcome && payouts ? (
           <TDStyled textAlign={TableCellsAlign[4]}>{formattedPayout}</TDStyled>

--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -200,12 +200,16 @@ export const OutcomeTable = (props: Props) => {
         {disabledColumns.includes(OutcomeTableValue.OutcomeProbability) ? null : withWinningOutcome ? (
           <TDStyled textAlign={TableCellsAlign[1]}>
             <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
-            {!shares.isZero() && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
+            {!shares.isZero() && disabledColumns.includes(OutcomeTableValue.Shares) && (
+              <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />
+            )}
           </TDStyled>
         ) : (
           <TDStyled textAlign={TableCellsAlign[1]}>
             <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
-            {!shares.isZero() && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
+            {!shares.isZero() && disabledColumns.includes(OutcomeTableValue.Shares) && (
+              <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />
+            )}
           </TDStyled>
         )}
         {disabledColumns.includes(OutcomeTableValue.Outcome) ? null : (

--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -198,12 +198,7 @@ export const OutcomeTable = (props: Props) => {
             />
           </TDRadio>
         )}
-        {disabledColumns.includes(OutcomeTableValue.OutcomeProbability) ? null : withWinningOutcome ? (
-          <TDStyled textAlign={TableCellsAlign[1]}>
-            <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
-            {showOwnedSharesMessage && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
-          </TDStyled>
-        ) : (
+        {disabledColumns.includes(OutcomeTableValue.OutcomeProbability) ? null : (
           <TDStyled textAlign={TableCellsAlign[1]}>
             <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
             {showOwnedSharesMessage && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
@@ -222,14 +217,7 @@ export const OutcomeTable = (props: Props) => {
         {disabledColumns.includes(OutcomeTableValue.Probability) ? null : (
           <TDStyled textAlign={TableCellsAlign[5]}>{probability.toFixed(2)}%</TDStyled>
         )}
-        {disabledColumns.includes(OutcomeTableValue.CurrentPrice) ? null : withWinningOutcome ? (
-          <TDStyled textAlign={TableCellsAlign[2]}>
-            <TDFlexDiv textAlign={TableCellsAlign[2]}>
-              {currentPriceFormatted}{' '}
-              {showSharesAndPriceChange && <NewValue outcomeIndex={outcomeIndex} value="1.23" />}
-            </TDFlexDiv>
-          </TDStyled>
-        ) : (
+        {disabledColumns.includes(OutcomeTableValue.CurrentPrice) ? null : (
           <TDStyled textAlign={TableCellsAlign[2]}>
             <TDFlexDiv textAlign={TableCellsAlign[2]}>
               {currentPriceFormatted}{' '}
@@ -237,15 +225,11 @@ export const OutcomeTable = (props: Props) => {
             </TDFlexDiv>
           </TDStyled>
         )}
-        {disabledColumns.includes(OutcomeTableValue.Shares) ? null : withWinningOutcome ? (
-          <TDStyled textAlign={TableCellsAlign[3]}>{formattedShares}</TDStyled>
-        ) : (
+        {disabledColumns.includes(OutcomeTableValue.Shares) ? null : (
           <TDStyled textAlign={TableCellsAlign[3]}>{formattedShares}</TDStyled>
         )}
-        {disabledColumns.includes(OutcomeTableValue.Payout) ? null : withWinningOutcome && payouts ? (
-          <TDStyled textAlign={TableCellsAlign[4]}>{formattedPayout}</TDStyled>
-        ) : (
-          <TDStyled textAlign={TableCellsAlign[4]}>0.00</TDStyled>
+        {disabledColumns.includes(OutcomeTableValue.Payout) ? null : (
+          <TDStyled textAlign={TableCellsAlign[4]}>{withWinningOutcome && payouts ? formattedPayout : '0.00'}</TDStyled>
         )}
       </TR>
     )

--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -130,7 +130,7 @@ export const OutcomeTable = (props: Props) => {
     const { balance, index } = props
     const shares = new Big(balance.shares.toString())
 
-    if (!payouts || !shares.eq(0)) return null
+    if (!payouts || shares.eq(0)) return null
 
     const redeemable = new BigNumber(shares.mul(payouts[index]).toString())
 
@@ -180,8 +180,9 @@ export const OutcomeTable = (props: Props) => {
     const isOutcomeSelected = outcomeSelected === outcomeIndex
     const showSharesAndPriceChange = isOutcomeSelected && !IS_CORONA_VERSION
     const formattedPayout = formatBigNumber(mulBN(shares, payout), collateral.decimals)
-    const isWinningOutcome = payouts && payouts[outcomeIndex] > 0
     const formattedShares = formatBigNumber(shares, collateral.decimals)
+    const isWinningOutcome = payouts && payouts[outcomeIndex] > 0
+    const showOwnedSharesMessage = !shares.isZero() && disabledColumns.includes(OutcomeTableValue.Shares)
 
     return (
       <TR key={outcomeName}>
@@ -200,16 +201,12 @@ export const OutcomeTable = (props: Props) => {
         {disabledColumns.includes(OutcomeTableValue.OutcomeProbability) ? null : withWinningOutcome ? (
           <TDStyled textAlign={TableCellsAlign[1]}>
             <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
-            {!shares.isZero() && disabledColumns.includes(OutcomeTableValue.Shares) && (
-              <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />
-            )}
+            {showOwnedSharesMessage && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
           </TDStyled>
         ) : (
           <TDStyled textAlign={TableCellsAlign[1]}>
             <BarDiagram outcomeIndex={outcomeIndex} outcomeName={outcomeName} probability={probability} />
-            {!shares.isZero() && disabledColumns.includes(OutcomeTableValue.Shares) && (
-              <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />
-            )}
+            {showOwnedSharesMessage && <OwnedShares outcomeIndex={outcomeIndex} value={formattedShares} />}
           </TDStyled>
         )}
         {disabledColumns.includes(OutcomeTableValue.Outcome) ? null : (

--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -175,24 +175,18 @@ export const ClosedMarketDetail = (props: Props) => {
             ></MarketResolutionMessageStyled>
           )}
           {isConditionResolved && !hasWinningOutcomes ? null : (
-            <>
-              <ButtonContainerFullWidth borderTop={true}>
-                {!isConditionResolved && (
-                  <Button
-                    buttonType={ButtonType.primary}
-                    disabled={status === Status.Loading}
-                    onClick={resolveCondition}
-                  >
-                    Resolve Condition
-                  </Button>
-                )}
-                {isConditionResolved && hasWinningOutcomes && (
-                  <Button buttonType={ButtonType.primary} disabled={status === Status.Loading} onClick={() => redeem()}>
-                    Redeem
-                  </Button>
-                )}
-              </ButtonContainerFullWidth>
-            </>
+            <ButtonContainerFullWidth borderTop={true}>
+              {!isConditionResolved && (
+                <Button buttonType={ButtonType.primary} disabled={status === Status.Loading} onClick={resolveCondition}>
+                  Resolve Condition
+                </Button>
+              )}
+              {isConditionResolved && hasWinningOutcomes && (
+                <Button buttonType={ButtonType.primary} disabled={status === Status.Loading} onClick={() => redeem()}>
+                  Redeem
+                </Button>
+              )}
+            </ButtonContainerFullWidth>
           )}
         </WhenConnected>
       </ViewCard>


### PR DESCRIPTION
Closes #534
Closes #515 

It was requested to show the "Shares" column on the Buy and Sell sections, but this is actually addressed by the design as seen here: https://www.figma.com/file/fDKaHCCfwqmOmOBg5xkSoo/Pages?node-id=774%3A590

It should look like these now:

![Screen Shot 2020-04-14 at 17 42 04](https://user-images.githubusercontent.com/4015436/79273135-e61c2180-7e78-11ea-891f-499aeceb968f.png)
![Screen Shot 2020-04-14 at 17 43 57](https://user-images.githubusercontent.com/4015436/79273147-e87e7b80-7e78-11ea-8613-a54d7980cb1c.png)
