### PR TITLE
(Fix) Text changes

### DIFF
--- a/app/src/components/common/text/section_title/index.tsx
+++ b/app/src/components/common/text/section_title/index.tsx
@@ -5,6 +5,12 @@ import styled from 'styled-components'
 import { ButtonCircle } from '../../../button'
 import { IconArrowBack } from '../../icons/IconArrowBack'
 
+export enum TextAlign {
+  left = 'left',
+  center = 'center',
+  right = 'right',
+}
+
 const Wrapper = styled.div`
   align-items: center;
   display: flex;
@@ -14,7 +20,7 @@ const Wrapper = styled.div`
   width: ${props => props.theme.mainContainer.maxWidth};
 `
 
-const Text = styled.h1<{ backButtonEnabled: boolean }>`
+const Text = styled.h1<{ backButtonEnabled: boolean; textAlign: TextAlign }>`
   color: #333;
   flex-grow: 1;
   font-size: 16px;
@@ -24,16 +30,17 @@ const Text = styled.h1<{ backButtonEnabled: boolean }>`
   padding-left: 25px;
   padding-right: ${props =>
     props.backButtonEnabled ? `${parseInt(props.theme.buttonCircle.dimensions + 25)}px` : '25px'};
-  text-align: center;
+  text-align: ${props => props.textAlign};
 `
 
 interface Props extends HTMLAttributes<HTMLDivElement>, RouteComponentProps<any> {
   backTo?: string
+  textAlign?: TextAlign
   title: string
 }
 
 export const SectionTitleWrapper: React.FC<Props> = (props: Props) => {
-  const { backTo = '', title, ...restProps } = props
+  const { textAlign = TextAlign.center, backTo = '', title, ...restProps } = props
   const enableGoBack = backTo !== ''
 
   return (
@@ -43,7 +50,7 @@ export const SectionTitleWrapper: React.FC<Props> = (props: Props) => {
           <IconArrowBack />
         </ButtonCircle>
       )}
-      <Text backButtonEnabled={enableGoBack} className="titleText">
+      <Text backButtonEnabled={enableGoBack} className="titleText" textAlign={textAlign}>
         {title}
       </Text>
     </Wrapper>

--- a/app/src/components/market/common/set_allowance/index.tsx
+++ b/app/src/components/market/common/set_allowance/index.tsx
@@ -43,7 +43,7 @@ export const SetAllowance: React.FC<SetAllowanceProps> = (props: SetAllowancePro
       <Title>Set Allowance</Title>
       <DescriptionWrapper>
         <Description>
-          This permission allows Omen smart contracts to interact with your {collateral.symbol}. This has to be done for
+          This permission allows the smart contracts to interact with your {collateral.symbol}. This has to be done for
           each new token.
         </Description>
         <ToggleTokenLock finished={finished} loading={loading} onUnlock={onUnlock} />

--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -19,7 +19,7 @@ import { Button, ButtonContainer } from '../../../button'
 import { ButtonType } from '../../../button/button_styling_types'
 import { BigNumberInput, TextfieldCustomPlaceholder } from '../../../common'
 import { BigNumberInputReturn } from '../../../common/form/big_number_input'
-import { SectionTitle } from '../../../common/text/section_title'
+import { SectionTitle, TextAlign } from '../../../common/text/section_title'
 import { FullLoading } from '../../../loading'
 import { ModalTwitterShare } from '../../../modal/modal_twitter_share'
 import { GridTransactionDetails } from '../../common/grid_transaction_details'
@@ -170,7 +170,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
 
   return (
     <>
-      <SectionTitle backTo={goBackToAddress} title={question.title} />
+      <SectionTitle backTo={goBackToAddress} textAlign={TextAlign.left} title={question.title} />
       <ViewCard>
         <MarketTopDetails
           marketMakerData={marketMakerData}

--- a/app/src/components/market/sections/market_create/market_wizard_creator.tsx
+++ b/app/src/components/market/sections/market_create/market_wizard_creator.tsx
@@ -250,7 +250,6 @@ export const MarketWizardCreator = (props: Props) => {
             values={marketData}
           />
         )
-
       default:
         return (
           <AskQuestionStep

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -19,7 +19,7 @@ import { Button, ButtonContainer, ButtonTab } from '../../../button'
 import { ButtonType } from '../../../button/button_styling_types'
 import { BigNumberInput, TextfieldCustomPlaceholder } from '../../../common'
 import { BigNumberInputReturn } from '../../../common/form/big_number_input'
-import { SectionTitle } from '../../../common/text/section_title'
+import { SectionTitle, TextAlign } from '../../../common/text/section_title'
 import { FullLoading } from '../../../loading'
 import { GridTransactionDetails } from '../../common/grid_transaction_details'
 import { MarketTopDetails } from '../../common/market_top_details'
@@ -173,7 +173,7 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
 
   return (
     <>
-      <SectionTitle backTo={goBackToAddress} title={question.title} />
+      <SectionTitle backTo={goBackToAddress} textAlign={TextAlign.left} title={question.title} />
       <ViewCard>
         <MarketTopDetails
           marketMakerData={marketMakerData}

--- a/app/src/components/market/sections/market_profile/market_view.tsx
+++ b/app/src/components/market/sections/market_profile/market_view.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet'
 
 import { DOCUMENT_TITLE } from '../../../../common/constants'
 import { MarketMakerData } from '../../../../util/types'
-import { SectionTitle } from '../../../common/text/section_title'
+import { SectionTitle, TextAlign } from '../../../common/text/section_title'
 
 import { ClosedMarketDetail } from './market_status/closed'
 import { OpenMarketDetails } from './market_status/open'
@@ -27,7 +27,7 @@ const MarketView: React.FC<Props> = (props: Props) => {
       <Helmet>
         <title>{`${question.title} - ${DOCUMENT_TITLE}`}</title>
       </Helmet>
-      <SectionTitle backTo="/" title={question.title} />
+      <SectionTitle backTo="/" textAlign={TextAlign.left} title={question.title} />
       {renderView()}
     </>
   )

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -14,7 +14,7 @@ import { Button, ButtonContainer } from '../../../button'
 import { ButtonType } from '../../../button/button_styling_types'
 import { BigNumberInput, TextfieldCustomPlaceholder } from '../../../common'
 import { BigNumberInputReturn } from '../../../common/form/big_number_input'
-import { SectionTitle } from '../../../common/text/section_title'
+import { SectionTitle, TextAlign } from '../../../common/text/section_title'
 import { FullLoading } from '../../../loading'
 import { GridTransactionDetails } from '../../common/grid_transaction_details'
 import { MarketTopDetails } from '../../common/market_top_details'
@@ -138,7 +138,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
 
   return (
     <>
-      <SectionTitle backTo={goBackToAddress} title={question.title} />
+      <SectionTitle backTo={goBackToAddress} textAlign={TextAlign.left} title={question.title} />
       <ViewCard>
         <MarketTopDetails
           marketMakerData={marketMakerData}

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -56,7 +56,7 @@ export interface Question {
 export enum OutcomeTableValue {
   OutcomeProbability = 'Outcome/Probability',
   CurrentPrice = 'Price',
-  Shares = 'Shares',
+  Shares = 'My Shares',
   Payout = 'Payout',
   Outcome = 'Outcome',
   Probability = 'Probability',


### PR DESCRIPTION
Closes #542

- Changed "Shares" for "My Shares"
- Aligned markets' title (and only market's title) to the left. The other titles remain as they were before.
- Remove "Omen" wording under Set Allowance box

**Screenshots:**

![Screen Shot 2020-04-15 at 17 55 13](https://user-images.githubusercontent.com/4015436/79388291-732bad00-7f43-11ea-9adc-d7b52608815e.png)
![Screen Shot 2020-04-15 at 17 55 28](https://user-images.githubusercontent.com/4015436/79388296-76bf3400-7f43-11ea-9218-3946dd3b7cf9.png)
![Screen Shot 2020-04-15 at 17 55 54](https://user-images.githubusercontent.com/4015436/79388297-7757ca80-7f43-11ea-9ab2-7c732502401a.png)
![Screen Shot 2020-04-15 at 17 57 44](https://user-images.githubusercontent.com/4015436/79388298-77f06100-7f43-11ea-82f3-a09a05a7ee9a.png)
