### PR TITLE
Fix how we check if the question is finalized

### DIFF
--- a/app/src/hooks/useBlockchainMarketMakerData.tsx
+++ b/app/src/hooks/useBlockchainMarketMakerData.tsx
@@ -71,7 +71,10 @@ export const useBlockchainMarketMakerData = (graphMarketMakerData: Maybe<GraphMa
 
     const { outcomes } = graphMarketMakerData.question
 
-    const isQuestionFinalized = !!graphMarketMakerData.answerFinalizedTimestamp
+    const isQuestionFinalized = graphMarketMakerData.answerFinalizedTimestamp
+      ? Date.now() > 1000 * graphMarketMakerData.answerFinalizedTimestamp.toNumber()
+      : false
+
     const {
       collateral,
       isConditionResolved,


### PR DESCRIPTION
Closes #524.

The problem was that we were considering a question as finalized whenever there was an `answerFinalizedTimestamp`. This value is actually the sum of the timestamp of the last answer plus the timeout. For example, if the timeout is of 1h and an answer is submitted at 1 PM, then `answerFinalizedTimestamp` will be 2 PM. If at 1:50 PM someone submits a new answer, then `answerFinalizedTimestamp` will become 2:50 PM. So we need to check the current time against the finalized timestamp (Realitio won't accept answers when the finalized timestamp is in the past, so the question is finalized).