### PR TITLE
(fix) squished looks

### DIFF
--- a/app/src/components/common/disclaimer/index.tsx
+++ b/app/src/components/common/disclaimer/index.tsx
@@ -9,6 +9,7 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: center;
   flex-direction: column;
+  flex-shrink: 0;
   margin: 0 auto;
   max-width: 100%;
   padding: 10px;


### PR DESCRIPTION
No related issue.

Simple fix for disclaimer's squished looks on Safari / Brave and some other browsers.

**Before:**

![Screen Shot 2020-04-23 at 16 25 05](https://user-images.githubusercontent.com/4015436/80145104-0a1ce880-8586-11ea-8cd3-133af032babe.png)

**After**

![Screen Shot 2020-04-23 at 16 33 00](https://user-images.githubusercontent.com/4015436/80145113-0db06f80-8586-11ea-9d2f-62a0e302d28a.png)
