### PR TITLE
Merge outcomes and transfer earned collateral to user

### DIFF
--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -64,7 +64,7 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const { account, library: provider } = context
   const cpk = useCpk()
 
-  const { buildMarketMaker } = useContracts(context)
+  const { buildMarketMaker, conditionalTokens } = useContracts(context)
   const marketMaker = buildMarketMaker(marketMakerAddress)
 
   const signer = useMemo(() => provider.getSigner(), [provider])
@@ -146,11 +146,19 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
 
       setMessage(`Withdrawing funds: ${fundsAmount} ${collateral.symbol}...`)
 
+      const collateralAddress = await marketMaker.getCollateralToken()
+      const conditionId = await marketMaker.getConditionId()
       const cpk = await CPKService.create(provider)
 
       await cpk.removeFunding({
-        amount: amountToRemove,
+        amountToMerge: depositedTokens,
+        collateralAddress,
+        conditionId,
+        conditionalTokens,
+        earnings: userEarnings,
         marketMaker,
+        outcomesCount: balances.length,
+        sharesToBurn: amountToRemove,
       })
 
       setStatus(Status.Ready)

--- a/app/src/services/conditional_token.ts
+++ b/app/src/services/conditional_token.ts
@@ -1,6 +1,6 @@
 import { Contract, Wallet, ethers, utils } from 'ethers'
 import { TransactionReceipt } from 'ethers/providers'
-import { BigNumber } from 'ethers/utils'
+import { BigNumber, BigNumberish } from 'ethers/utils'
 
 import { getLogger } from '../util/logger'
 import { getEarliestBlockToCheck } from '../util/networks'
@@ -21,6 +21,7 @@ const conditionalTokensAbi = [
   'function balanceOf(address owner, uint256 positionId) external view returns (uint256)',
   'function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes data) external',
   'function getOutcomeSlotCount(bytes32 conditionId) external view returns (uint)',
+  'function mergePositions(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] partition, uint amount) external',
 ]
 
 class ConditionalTokenService {
@@ -193,6 +194,24 @@ class ConditionalTokenService {
       ethers.constants.HashZero,
       conditionId,
       indexSets,
+    ])
+  }
+
+  static encodeMergePositions = (
+    collateralToken: string,
+    conditionId: string,
+    outcomesCount: number,
+    amount: BigNumberish,
+  ): string => {
+    const redeemPositionsInterface = new utils.Interface(conditionalTokensAbi)
+    const indexSets = getIndexSets(outcomesCount)
+
+    return redeemPositionsInterface.functions.mergePositions.encode([
+      collateralToken,
+      ethers.constants.HashZero,
+      conditionId,
+      indexSets,
+      amount,
     ])
   }
 }

--- a/app/src/services/market_maker.ts
+++ b/app/src/services/market_maker.ts
@@ -120,6 +120,9 @@ class MarketMakerService {
     return calcPrice(holdings)
   }
 
+  /**
+   * Return the holdings of each outcome for the given address
+   */
   getBalanceInformation = async (ownerAddress: string, outcomeQuantity: number): Promise<BigNumber[]> => {
     const conditionId = await this.getConditionId()
     const collateralTokenAddress = await this.getCollateralToken()

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -7,6 +7,9 @@ import { getLogger } from './logger'
 
 const logger = getLogger('Tools')
 
+// use floor as rounding method
+Big.RM = 0
+
 export const truncateStringInTheMiddle = (str: string, strPositionStart: number, strPositionEnd: number) => {
   const minTruncatedLength = strPositionStart + strPositionEnd
   if (minTruncatedLength < str.length) {


### PR DESCRIPTION
Closes #417.

When a user removes funding, they get all their accumulated fee plus an amount of outcome tokens proportional to how many pool shares they are burning. For example here:

![image](https://user-images.githubusercontent.com/417134/80236606-b5cf4280-8631-11ea-83cd-c94455aeda7f.png)

The user will get 0.01 of fee. The second row is the amount of collateral they will receive by merging tokens.

This is done with three transactions by the CPK:

1. Remove the funding
2. Merge the maximum amount of outcome tokens possible
3. Transfer back to the user the fees plus the collateral obtained by merging