### PR TITLE
Import 3box component dynamically

### DIFF
--- a/app/src/components/comments/index.tsx
+++ b/app/src/components/comments/index.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+import { IS_CORONA_VERSION } from '../../common/constants'
+
+import { DisqusComments } from './disqus_comments'
+
+interface Props {
+  marketMakerAddress: string
+}
+
+export const Comments: React.FC<Props> = ({ marketMakerAddress }) => {
+  const ThreeBoxCommentsRef = useRef<any>()
+  const [show3box, setShow3Box] = useState(false)
+
+  useEffect(() => {
+    if (!IS_CORONA_VERSION) {
+      import('./three_box_comments').then(ThreeBoxCommentsModule => {
+        ThreeBoxCommentsRef.current = ThreeBoxCommentsModule.ThreeBoxComments
+        setShow3Box(true)
+      })
+    }
+  }, [])
+
+  if (IS_CORONA_VERSION) {
+    return <DisqusComments marketMakerAddress={marketMakerAddress} />
+  }
+
+  if (!ThreeBoxCommentsRef.current || !show3box) {
+    return null
+  }
+
+  return <ThreeBoxCommentsRef.current threadName={marketMakerAddress} />
+}

--- a/app/src/components/market/routes/market_routes.tsx
+++ b/app/src/components/market/routes/market_routes.tsx
@@ -3,13 +3,13 @@ import { ethers } from 'ethers'
 import React from 'react'
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 
-import { FETCH_DETAILS_INTERVAL, IS_CORONA_VERSION, MARKET_FEE } from '../../../common/constants'
+import { FETCH_DETAILS_INTERVAL, MARKET_FEE } from '../../../common/constants'
 import { useCheckContractExists, useMarketMakerData } from '../../../hooks'
 import { useConnectedWeb3Context } from '../../../hooks/connectedWeb3'
 import { MarketBuyPage, MarketDetailsPage, MarketPoolLiquidityPage, MarketSellPage } from '../../../pages'
 import { getLogger } from '../../../util/logger'
 import { isAddress } from '../../../util/tools'
-import { DisqusComments } from '../../comments/disqus_comments'
+import { Comments } from '../../comments'
 import { SectionTitle } from '../../common'
 import { Message, MessageType } from '../../common/message'
 import { InlineLoading } from '../../loading'
@@ -83,8 +83,7 @@ const MarketValidation: React.FC<Props> = (props: Props) => {
             />
           </>
         )}
-        {IS_CORONA_VERSION ? <DisqusComments marketMakerAddress={marketMakerAddress} /> : null}
-        {/* <ThreeBoxComments threadName={marketMakerAddress} /> */}
+        <Comments marketMakerAddress={marketMakerAddress} />
       </>
     </Switch>
   )


### PR DESCRIPTION
Part of #435.

Add a new `Comments` component that shows 3box for Omen and Disqus for Corona Markets. Also, the 3box component is loaded asynchronously, so the main bundle size isn't increased.

I didn't update 3box because it stops working, even if the API didn't change. I guess that should be investigated in a different PR.