### PR TITLE
(fix) connect button's states

### DIFF
--- a/app/src/components/modal/modal_connect_wallet/index.tsx
+++ b/app/src/components/modal/modal_connect_wallet/index.tsx
@@ -145,7 +145,7 @@ export const ModalConnectWallet = (props: Props) => {
     onClose()
   }
 
-  const doesMetamaskExist = 'ethereum' in window || 'web3' in window
+  const isMetamaskEnabled = 'ethereum' in window || 'web3' in window
   const onClickWallet = (wallet: Wallet) => {
     if (wallet === Wallet.WalletConnect) {
       setConnectingToWalletConnect(true)
@@ -207,6 +207,9 @@ export const ModalConnectWallet = (props: Props) => {
   const isConnectingToWallet = connectingToMetamask || connectingToWalletConnect
   const connectingText = connectingToMetamask ? 'Waiting for Approval on Metamask' : 'Opening QR for Wallet Connect'
 
+  const disableMetamask = !isMetamaskEnabled || (LINK_TERMS_AND_CONDITIONS && !acceptedTerms) || false
+  const disableWalletConnect = (LINK_TERMS_AND_CONDITIONS && !acceptedTerms) || false
+
   return (
     <>
       <ModalWrapper
@@ -225,15 +228,16 @@ export const ModalConnectWallet = (props: Props) => {
             <>
               <Buttons>
                 <ConnectButton
-                  disabled={!doesMetamaskExist || !acceptedTerms}
+                  disabled={disableMetamask}
                   icon={<IconMetaMask />}
                   onClick={() => {
                     onClickWallet(Wallet.MetaMask)
                   }}
                   text="Metamask"
                 />
+
                 <ConnectButton
-                  disabled={!acceptedTerms}
+                  disabled={disableWalletConnect}
                   icon={<IconWalletConnect />}
                   onClick={() => {
                     onClickWallet(Wallet.WalletConnect)


### PR DESCRIPTION
Closes #633

Logic should work as follows now:

- No Metamask plugin / Metamask plugin disabled: MM button is disabled.
- Metamask plugin enabled and no T&C: MM button is enabled.
- Metamask plugin enabled and T&C no accepted: MM button is disabled.
- Metamask plugin enabled and T&C accepted: MM button is enabled.
- No T&C exists: WC button enabled.
- T&C no accepted: WC button disabled.
- T&C accepted: WC button enabled.