### PR TITLE
(Fix) Usability issue on market list and buy outcome

### DIFF
--- a/app/src/components/market/common/list_item/index.tsx
+++ b/app/src/components/market/common/list_item/index.tsx
@@ -42,6 +42,10 @@ const Info = styled.div`
   white-space: nowrap;
 `
 
+const OutcomeTitle = styled.span`
+  color: ${props => props.theme.colors.textColor};
+`
+
 const Outcome = styled.span`
   color: ${props => props.theme.colors.primary};
 `
@@ -88,7 +92,10 @@ export const ListItem: React.FC<Props> = (props: Props) => {
     <Wrapper to={address}>
       <Title>{title}</Title>
       <Info>
-        <Outcome>{outcomes && `${(percentages[indexMax] * 100).toFixed(2)}% ${outcomes[indexMax]} `}</Outcome>
+        <Outcome>
+          <OutcomeTitle>Top Outcome:</OutcomeTitle>{' '}
+          {outcomes && `${outcomes[indexMax]} (${(percentages[indexMax] * 100).toFixed(2)}%)`}
+        </Outcome>
         <Separator>·</Separator>
         <span>
           {amount} {symbol} Volume

--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { formatBigNumber, mulBN } from '../../../../util/tools'
@@ -38,6 +38,18 @@ const PaddingCSS = css`
     padding-right: 25px;
   }
 `
+
+const TRExtended = styled(TR)<{ clickable?: boolean }>`
+  cursor: ${props => (props.clickable ? 'pointer' : 'default')};
+
+  &:hover td {
+    background-color: ${props => (props.clickable ? '#fafafa' : 'transparent')};
+  }
+`
+
+TRExtended.defaultProps = {
+  clickable: false,
+}
 
 const THStyled = styled(TH)`
   ${PaddingCSS}
@@ -108,6 +120,13 @@ export const OutcomeTable = (props: Props) => {
     )
   }
 
+  const selectRow = useCallback(
+    (index: number) => {
+      outcomeHandleChange && outcomeHandleChange(index)
+    },
+    [outcomeHandleChange],
+  )
+
   const renderTableRow = (balanceItem: BalanceItem, outcomeIndex: number) => {
     const { currentPrice, outcomeName, payout, shares } = balanceItem
     const currentPriceFormatted = withWinningOutcome ? payout : Number(currentPrice).toFixed(2)
@@ -118,14 +137,18 @@ export const OutcomeTable = (props: Props) => {
     const isWinningOutcome = payouts && payouts[outcomeIndex] > 0
 
     return (
-      <TR key={`${outcomeName}-${outcomeIndex}`}>
+      <TRExtended
+        clickable={displayRadioSelection}
+        key={`${outcomeName}-${outcomeIndex}`}
+        onClick={() => selectRow(outcomeIndex)}
+      >
         {!displayRadioSelection || withWinningOutcome ? null : (
           <TDRadio textAlign={TableCellsAlign[0]}>
             <RadioInput
               checked={outcomeSelected === outcomeIndex}
               data-testid={`outcome_table_radio_${balanceItem.outcomeName}`}
               name="outcome"
-              onChange={(e: any) => outcomeHandleChange && outcomeHandleChange(+e.target.value)}
+              onChange={(e: any) => selectRow(+e.target.value)}
               outcomeIndex={outcomeIndex}
               value={outcomeIndex}
             />
@@ -172,7 +195,7 @@ export const OutcomeTable = (props: Props) => {
         {disabledColumns.includes(OutcomeTableValue.Payout) ? null : (
           <TDStyled textAlign={TableCellsAlign[4]}>{withWinningOutcome && payouts ? formattedPayout : '0.00'}</TDStyled>
         )}
-      </TR>
+      </TRExtended>
     )
   }
 


### PR DESCRIPTION
Closes #577

- Made outcomes row fully clickable when there's a radio button in it.
- Changed markets list items wording a bit to make the bottom text easier to understand.

**Screenshots:**

![Screen Shot 2020-05-06 at 18 03 40](https://user-images.githubusercontent.com/4015436/81228825-262c7b00-8fc5-11ea-93e7-b53962597439.png)

![May-06-2020 18-04-52](https://user-images.githubusercontent.com/4015436/81228842-2b89c580-8fc5-11ea-8f1e-93ac24d0b14d.gif)
![May-06-2020 18-07-09](https://user-images.githubusercontent.com/4015436/81228852-32183d00-8fc5-11ea-8277-bf8f6b2d9941.gif)
