### PR TITLE
(fix) Overly attached spinner

### DIFF
--- a/app/src/components/market/sections/market_list/market_home.tsx
+++ b/app/src/components/market/sections/market_list/market_home.tsx
@@ -221,6 +221,10 @@ export const MarketHome: React.FC<Props> = (props: Props) => {
     return !context.account || !SHOW_MY_MARKETS ? f.state !== MarketStates.myMarkets : true
   }
 
+  const noMarketsAvailable = RemoteData.is.success(markets) && markets.data.length === 0
+  const showFilteringInlineLoading = !noMarketsAvailable && isFiltering
+  const showLoadMoreButton = !isFiltering && moreMarkets && !RemoteData.is.loading(markets)
+
   return (
     <>
       <SectionTitleMarket title={'Markets'} />
@@ -279,12 +283,10 @@ export const MarketHome: React.FC<Props> = (props: Props) => {
             markets.data.slice(0, count).map(item => {
               return <ListItem key={item.address} market={item}></ListItem>
             })}
-          {RemoteData.is.success(markets) && markets.data.length === 0 && (
-            <NoMarketsAvailable>No markets available.</NoMarketsAvailable>
-          )}
-          {isFiltering && <InlineLoading message="Loading Markets..." />}
+          {noMarketsAvailable && <NoMarketsAvailable>No markets available.</NoMarketsAvailable>}
+          {showFilteringInlineLoading && <InlineLoading message="Loading Markets..." />}
         </ListWrapper>
-        {!isFiltering && moreMarkets && !RemoteData.is.loading(markets) && (
+        {showLoadMoreButton && (
           <LoadMoreWrapper>
             <Button
               buttonType={ButtonType.secondaryLine}

--- a/app/src/components/market/sections/market_list/market_home_container.tsx
+++ b/app/src/components/market/sections/market_list/market_home_container.tsx
@@ -115,7 +115,6 @@ const MarketHomeContainer: React.FC = () => {
       setMarkets(markets => (RemoteData.hasData(markets) ? RemoteData.reloading(markets.data) : RemoteData.loading()))
     } else if (fetchedMarkets) {
       const { fixedProductMarketMakers } = fetchedMarkets
-
       setMarkets(RemoteData.success(wrangleResponse(fixedProductMarketMakers, context.networkId)))
 
       if (fixedProductMarketMakers.length < PAGE_SIZE) {


### PR DESCRIPTION
Closes #639 

This was the problem:

![May-08-2020 11-44-29](https://user-images.githubusercontent.com/4015436/81444440-85b59280-914d-11ea-8aa7-1f641affae14.gif)

It should work like this now:

![May-08-2020 16-57-26](https://user-images.githubusercontent.com/4015436/81444483-949c4500-914d-11ea-962c-a428828b2e5a.gif)
