### PR TITLE
Show shares that will be received when a market is created

### DIFF
--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -12,7 +12,12 @@ import {
 } from '../../../../../../hooks'
 import { BalanceState, fetchAccountBalance } from '../../../../../../store/reducer'
 import { MarketCreationStatus } from '../../../../../../util/market_creation_status_data'
-import { formatBigNumber, formatDate } from '../../../../../../util/tools'
+import {
+  calcDistributionHint,
+  calcInitialFundingSendAmounts,
+  formatBigNumber,
+  formatDate,
+} from '../../../../../../util/tools'
 import { Arbitrator, Token } from '../../../../../../util/types'
 import { Button } from '../../../../../button'
 import { ButtonType } from '../../../../../button/button_styling_types'
@@ -167,6 +172,14 @@ const FundingAndFeeStep = (props: Props) => {
 
   const tokensAmount = useTokens(context).length
 
+  const distributionHint = calcDistributionHint(outcomes.map(outcome => outcome.probability))
+  const sharesAfterInitialFunding =
+    distributionHint.length > 0
+      ? calcInitialFundingSendAmounts(funding, distributionHint)
+      : outcomes.map(() => new BigNumber(0))
+
+  console.log(sharesAfterInitialFunding)
+
   return (
     <>
       <CreateCardTop>
@@ -194,7 +207,9 @@ const FundingAndFeeStep = (props: Props) => {
                     </OutcomesTD>
                     <OutcomesTD textAlign="right">{outcome.probability}%</OutcomesTD>
                     <OutcomesTD textAlign="right">
-                      <TDFlexDiv textAlign="right">0</TDFlexDiv>
+                      <TDFlexDiv textAlign="right">
+                        {formatBigNumber(sharesAfterInitialFunding[index], collateral.decimals)}
+                      </TDFlexDiv>
                     </OutcomesTD>
                   </OutcomesTR>
                 )

--- a/app/src/util/tools.spec.ts
+++ b/app/src/util/tools.spec.ts
@@ -6,6 +6,7 @@ import {
   calcAddFundingSendAmounts,
   calcDepositedTokens,
   calcDistributionHint,
+  calcInitialFundingSendAmounts,
   calcNetCost,
   calcPoolTokens,
   calcPrice,
@@ -300,7 +301,7 @@ describe('tools', () => {
       ))
   })
 
-  describe.only('calcAddFundingSendAmounts', () => {
+  describe('calcAddFundingSendAmounts', () => {
     it('all holdings are different', () => {
       const result = calcAddFundingSendAmounts(bigNumberify(10), [1, 2, 3].map(bigNumberify), bigNumberify(20)).map(x =>
         x.toString(),
@@ -321,6 +322,26 @@ describe('tools', () => {
       const result = calcAddFundingSendAmounts(bigNumberify(10), [3, 3, 3].map(bigNumberify), bigNumberify(0))
 
       expect(result).toBe(null)
+    })
+  })
+
+  describe('calcInitialFundingSendAmounts', () => {
+    it('all holdings are different', () => {
+      const result = calcInitialFundingSendAmounts(bigNumberify(10), [1, 2, 3].map(bigNumberify)).map(x => x.toString())
+
+      expect(result).toStrictEqual(['7', '4', '0'])
+    })
+
+    it('all holdings are equal', () => {
+      const result = calcInitialFundingSendAmounts(bigNumberify(10), [3, 3, 3].map(bigNumberify)).map(x => x.toString())
+
+      expect(result).toStrictEqual(['0', '0', '0'])
+    })
+
+    it('no funding', () => {
+      const result = calcInitialFundingSendAmounts(bigNumberify(0), [3, 3, 3].map(bigNumberify)).map(x => x.toString())
+
+      expect(result).toStrictEqual(['0', '0', '0'])
     })
   })
 })

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -201,6 +201,18 @@ export const calcPoolTokens = (
 
 /**
  * Compute the number of outcomes that will be sent to the user by the Market Maker
+ * after funding it for the first time with `addedFunds` of collateral.
+ */
+export const calcInitialFundingSendAmounts = (addedFunds: BigNumber, distributionHint: BigNumber[]): BigNumber[] => {
+  const maxHint = distributionHint.reduce((a, b) => (a.gt(b) ? a : b))
+
+  const sendAmounts = distributionHint.map(hint => addedFunds.sub(addedFunds.mul(hint).div(maxHint)))
+
+  return sendAmounts
+}
+
+/**
+ * Compute the number of outcomes that will be sent to the user by the Market Maker
  * after adding `addedFunds` of collateral.
  */
 export const calcAddFundingSendAmounts = (


### PR DESCRIPTION
Closes #705.

To test: create a market with uniform/non-uniform odds and check the funding screen. It should always show 0 for uniform odds, it should show 0 for non-uniform odds but no funding, and it should show some numbers when a funding amount is entered.