### PR TITLE
hotfix for disabling add if 100 percent is reached

### DIFF
--- a/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
+++ b/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
@@ -176,13 +176,14 @@ const Outcomes = (props: Props) => {
   const manualProbabilitiesAndNoOutcomes = manualProbabilities && outcomes.length === 0
   const maxOutcomesReached = outcomes.length >= MAX_OUTCOME_ALLOWED
   const outcomeValueOutofBounds = newOutcomeProbability <= outcomeMinValue || newOutcomeProbability >= outcomeMaxValue
+  const totalProbabilitiesReached = !uniformProbabilities && totalProbabilities === 100
   const disableButtonAdd =
     !newOutcomeName ||
     maxOutcomesReached ||
     (!uniformProbabilities && outcomeValueOutofBounds) ||
-    (!uniformProbabilities && totalProbabilities === 100) ||
+    totalProbabilitiesReached ||
     disabled
-  const disableManualProbabilities = maxOutcomesReached || disabled
+  const disableManualProbabilities = maxOutcomesReached || disabled || totalProbabilitiesReached
   const disableUniformProbabilities = !canAddOutcome || maxOutcomesReached || disabled
   const outcomeNameRef = React.createRef<any>()
 
@@ -223,7 +224,7 @@ const Outcomes = (props: Props) => {
       </TitleWrapper>
       <NewOutcome uniformProbabilities={uniformProbabilities}>
         <Textfield
-          disabled={disableUniformProbabilities}
+          disabled={disableUniformProbabilities || (!uniformProbabilities && totalProbabilitiesReached)}
           onChange={e => setNewOutcomeName(e.target.value)}
           onKeyUp={e => {
             onPressEnter(e)

--- a/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
+++ b/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
@@ -224,7 +224,7 @@ const Outcomes = (props: Props) => {
       </TitleWrapper>
       <NewOutcome uniformProbabilities={uniformProbabilities}>
         <Textfield
-          disabled={disableUniformProbabilities || (!uniformProbabilities && totalProbabilitiesReached)}
+          disabled={disableUniformProbabilities || totalProbabilitiesReached}
           onChange={e => setNewOutcomeName(e.target.value)}
           onKeyUp={e => {
             onPressEnter(e)

--- a/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
+++ b/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
@@ -106,9 +106,9 @@ interface Props {
 }
 
 const Outcomes = (props: Props) => {
-  const outcomeMinValue = 0
-  const outcomeMaxValue = 100
   const { canAddOutcome, disabled, outcomes, totalProbabilities } = props
+  const outcomeMinValue = 0
+  const outcomeMaxValue = 100 - totalProbabilities
   const [newOutcomeName, setNewOutcomeName] = useState<string>('')
   const [newOutcomeProbability, setNewOutcomeProbability] = useState<number>(outcomeMinValue)
   const [uniformProbabilities, setIsUniform] = useState<boolean>(true)
@@ -175,7 +175,7 @@ const Outcomes = (props: Props) => {
   const manualProbabilitiesAndThereAreOutcomes = manualProbabilities && outcomes.length > 0
   const manualProbabilitiesAndNoOutcomes = manualProbabilities && outcomes.length === 0
   const maxOutcomesReached = outcomes.length >= MAX_OUTCOME_ALLOWED
-  const outcomeValueOutofBounds = newOutcomeProbability <= outcomeMinValue || newOutcomeProbability >= outcomeMaxValue
+  const outcomeValueOutofBounds = newOutcomeProbability <= outcomeMinValue || newOutcomeProbability > outcomeMaxValue
   const totalProbabilitiesReached = !uniformProbabilities && totalProbabilities === 100
   const disableButtonAdd =
     !newOutcomeName ||

--- a/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
+++ b/app/src/components/market/sections/market_create/steps/outcomes/index.tsx
@@ -108,7 +108,7 @@ interface Props {
 const Outcomes = (props: Props) => {
   const outcomeMinValue = 0
   const outcomeMaxValue = 100
-  const { canAddOutcome, disabled, outcomes } = props
+  const { canAddOutcome, disabled, outcomes, totalProbabilities } = props
   const [newOutcomeName, setNewOutcomeName] = useState<string>('')
   const [newOutcomeProbability, setNewOutcomeProbability] = useState<number>(outcomeMinValue)
   const [uniformProbabilities, setIsUniform] = useState<boolean>(true)
@@ -177,7 +177,11 @@ const Outcomes = (props: Props) => {
   const maxOutcomesReached = outcomes.length >= MAX_OUTCOME_ALLOWED
   const outcomeValueOutofBounds = newOutcomeProbability <= outcomeMinValue || newOutcomeProbability >= outcomeMaxValue
   const disableButtonAdd =
-    !newOutcomeName || maxOutcomesReached || (!uniformProbabilities && outcomeValueOutofBounds) || disabled
+    !newOutcomeName ||
+    maxOutcomesReached ||
+    (!uniformProbabilities && outcomeValueOutofBounds) ||
+    (!uniformProbabilities && totalProbabilities === 100) ||
+    disabled
   const disableManualProbabilities = maxOutcomesReached || disabled
   const disableUniformProbabilities = !canAddOutcome || maxOutcomesReached || disabled
   const outcomeNameRef = React.createRef<any>()


### PR DESCRIPTION
For uniform probabilities, there was a need to maintain enabled the add button until each outcome has a probability of 100/MAX_OUTCOMES, but for manual probabilities the same button should be disabled once `totalProbabilities` reach 100% to avoid getting negative values at using `setMax`