### PR TITLE
(Fix) Mobile version

### DIFF
--- a/app/src/components/common/text/subsection_title_wrapper/index.tsx
+++ b/app/src/components/common/text/subsection_title_wrapper/index.tsx
@@ -4,8 +4,13 @@ import styled from 'styled-components'
 const Wrapper = styled.div`
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   margin-bottom: 20px;
+
+  @media (min-width: ${props => props.theme.themeBreakPoints.md}) {
+    flex-wrap: nowrap;
+  }
 `
 
 export const SubsectionTitleWrapper: React.FC = props => {

--- a/app/src/components/market/common/common_styled/index.tsx
+++ b/app/src/components/market/common/common_styled/index.tsx
@@ -142,7 +142,14 @@ export const TDFlexDiv = styled.div<{ textAlign?: string }>`
 export const SubsectionTitleActionWrapper = styled.div`
   align-items: center;
   display: flex;
-  margin-left: auto;
+  padding-top: 5px;
+  width: 100%;
+
+  @media (min-width: ${props => props.theme.themeBreakPoints.md}) {
+    margin-left: auto;
+    padding-top: 0;
+    width: auto;
+  }
 `
 export const Breaker = styled.div`
   &::before {

--- a/app/src/components/market/common/list_item/index.tsx
+++ b/app/src/components/market/common/list_item/index.tsx
@@ -33,6 +33,9 @@ const Title = styled.h2`
   font-weight: 500;
   line-height: 1.2;
   margin: 0 0 5px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 const Info = styled.div`
@@ -43,7 +46,9 @@ const Info = styled.div`
   font-size: 13px;
   font-weight: 700;
   line-height: 1.2;
-  white-space: nowrap;
+  overflow-wrap: break-word;
+  white-space: normal;
+  word-break: break-all;
 `
 
 const OutcomeTitle = styled.span`

--- a/app/src/theme/overrides/threebox_styles_override.tsx
+++ b/app/src/theme/overrides/threebox_styles_override.tsx
@@ -166,7 +166,9 @@ export const ThreeboxStylesOverride = css`
 
   footer {
     margin-bottom: 0;
+    overflow: hidden;
     padding-top: 20px;
+
     .footer_text {
       color: ${props => props.theme.colors.textColorLight};
       font-size: 12px;


### PR DESCRIPTION
Closes #695 

**Fixed:**

- Currently top outcome overlaps the screen.
- Outcome/Probably overlapping -> (actually that's according to the design, IIRC). Related to this, if any table overflows the container's width the user should be able to scroll to see the full contents.
- Whitespace in market detail view.
- A few more issues I found.